### PR TITLE
CMake patch

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,9 @@ function(generate_hsaco TARGET_ID INPUT_FILE OUTPUT_FILE)
 endfunction(generate_hsaco)
 
 set(GPU_LIST "gfx900" "gfx906" "gfx908" "gfx90a" "gfx942" "gfx1030" "gfx1031" "gfx1032" "gfx1100" "gfx1101" "gfx1102")
+# Create test_kernels directory if it doesn't exist
+file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/test_kernels)
+# Run generate_hsaco for each target
 foreach(target_id ${GPU_LIST})
     # generate kernel bitcodes
     message("${CMAKE_CURRENT_SOURCE_DIR}")


### PR DESCRIPTION
I encountered a build error when testing the project on HPCFund. Found that we need to create output directory, `test_kernels`, otherwise CMake will yell about a nonexistent directory. This small change seemed to do the trick

## System settings

```shell
(base) [colramos@login1 build]$ module list

Currently Loaded Modules:
  1) autotools   2) cmake/3.25.2   3) prun/2.3   4) rocm/6.1.2   5) gnu12/12.2.0   6) ucx/1.14.0   7) openmpi4/4.1.5   8) hpcfund
```

## Sample

**Old output❌:**
```shell
(base) [colramos@login1 build]$ cmake ..
ROCM_PATH: /opt/rocm-6.1.2
-- The CXX compiler identification is GNU 11.3.1
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /bin/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
----------------NBit: 64
----------Build-Type: release
------------Compiler: /bin/g++
----Compiler-Version: 11.3.1
-----HSA-Runtime-Inc: /opt/rocm-6.1.2/include/hsa
-----HSA-Runtime-Lib: /opt/rocm-6.1.2/lib
----HSA_KMT_LIB_PATH: /opt/rocm-6.1.2/lib
----COMGR_LIB_PATH  : /opt/rocm-6.1.2/lib
-------ROCM_ROOT_DIR: /opt/rocm-6.1.2
-----CMAKE_CXX_FLAGS:  -std=c++2a -Wall -Werror -Wno-braced-scalar-init -Wno-unused-lambda-capture -Wno-unused-function -Wno-unused-variable -Wno-switch-bool -Wno-unused-private-field -Werror=return-type -fexceptions -fvisibility=hidden -fno-math-errno -fno-threadsafe-statics -fmerge-all-constants -fms-extensions -fmerge-all-constants -Werror=unused-result -fPIC -m64  -msse -msse2
---CMAKE_PREFIX_PATH: /opt/rocm
---------GPU_TARGETS: 
-- LIB-VERSION STRING: 1.0.0
/home1/colramos/GitHub/logduration
generate_hsaco: /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl gfx900
/home1/colramos/GitHub/logduration
generate_hsaco: /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl gfx906
/home1/colramos/GitHub/logduration
generate_hsaco: /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl gfx908
/home1/colramos/GitHub/logduration
generate_hsaco: /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl gfx90a
/home1/colramos/GitHub/logduration
generate_hsaco: /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl gfx942
/home1/colramos/GitHub/logduration
generate_hsaco: /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl gfx1030
/home1/colramos/GitHub/logduration
generate_hsaco: /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl gfx1031
/home1/colramos/GitHub/logduration
generate_hsaco: /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl gfx1032
/home1/colramos/GitHub/logduration
generate_hsaco: /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl gfx1100
/home1/colramos/GitHub/logduration
generate_hsaco: /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl gfx1101
/home1/colramos/GitHub/logduration
generate_hsaco: /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl gfx1102
/home1/colramos/GitHub/logduration/build/test_kernels/gfx900_copy.hsaco;/home1/colramos/GitHub/logduration/build/test_kernels/gfx906_copy.hsaco;/home1/colramos/GitHub/logduration/build/test_kernels/gfx908_copy.hsaco;/home1/colramos/GitHub/logduration/build/test_kernels/gfx90a_copy.hsaco;/home1/colramos/GitHub/logduration/build/test_kernels/gfx942_copy.hsaco;/home1/colramos/GitHub/logduration/build/test_kernels/gfx1030_copy.hsaco;/home1/colramos/GitHub/logduration/build/test_kernels/gfx1031_copy.hsaco;/home1/colramos/GitHub/logduration/build/test_kernels/gfx1032_copy.hsaco;/home1/colramos/GitHub/logduration/build/test_kernels/gfx1100_copy.hsaco;/home1/colramos/GitHub/logduration/build/test_kernels/gfx1101_copy.hsaco;/home1/colramos/GitHub/logduration/build/test_kernels/gfx1102_copy.hsaco
CMake-install-prefix: /
CPack-install-prefix: /
-----------Dest-name: logDuration
-- Configuring done
-- Generating done
-- Build files have been written to: /home1/colramos/GitHub/logduration/build
(base) [colramos@login1 build]$ make 
/opt/ohpc/pub/utils/cmake/3.25.2/bin/cmake -S/home1/colramos/GitHub/logduration -B/home1/colramos/GitHub/logduration/build --check-build-system CMakeFiles/Makefile.cmake 0
/opt/ohpc/pub/utils/cmake/3.25.2/bin/cmake -E cmake_progress_start /home1/colramos/GitHub/logduration/build/CMakeFiles /home1/colramos/GitHub/logduration/build//CMakeFiles/progress.marks
make  -f CMakeFiles/Makefile2 all
make[1]: Entering directory '/home1/colramos/GitHub/logduration/build'
make  -f CMakeFiles/hsaco_targets.dir/build.make CMakeFiles/hsaco_targets.dir/depend
make[2]: Entering directory '/home1/colramos/GitHub/logduration/build'
cd /home1/colramos/GitHub/logduration/build && /opt/ohpc/pub/utils/cmake/3.25.2/bin/cmake -E cmake_depends "Unix Makefiles" /home1/colramos/GitHub/logduration /home1/colramos/GitHub/logduration /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/build/CMakeFiles/hsaco_targets.dir/DependInfo.cmake --color=
make[2]: Leaving directory '/home1/colramos/GitHub/logduration/build'
make  -f CMakeFiles/hsaco_targets.dir/build.make CMakeFiles/hsaco_targets.dir/build
make[2]: Entering directory '/home1/colramos/GitHub/logduration/build'
[  7%] /home1/colramos/GitHub/logduration/build/test_kernels/gfx900_copy.hsaco
cd /home1/colramos/GitHub/logduration/build/test_kernels && /opt/rocm-6.1.2/llvm/bin/clang -O2 -x cl -Xclang -finclude-default-header -cl-denorms-are-zero -cl-std=CL2.0 -Wl,--build-id=sha1 -target amdgcn-amd-amdhsa -mcpu=gfx900 -o gfx900_copy.hsaco /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl
/bin/sh: line 1: cd: /home1/colramos/GitHub/logduration/build/test_kernels: No such file or directory
make[2]: *** [CMakeFiles/hsaco_targets.dir/build.make:110: test_kernels/gfx900_copy.hsaco] Error 1
make[2]: Leaving directory '/home1/colramos/GitHub/logduration/build'
make[1]: *** [CMakeFiles/Makefile2:87: CMakeFiles/hsaco_targets.dir/all] Error 2
make[1]: Leaving directory '/home1/colramos/GitHub/logduration/build'
make: *** [Makefile:159: all] Error 2
```

**New output✅:**
```shell
(base) [colramos@login1 build]$ cmake ..
ROCM_PATH: /opt/rocm-6.1.2
-- The CXX compiler identification is GNU 11.3.1
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /bin/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
----------------NBit: 64
----------Build-Type: release
------------Compiler: /bin/g++
----Compiler-Version: 11.3.1
-----HSA-Runtime-Inc: /opt/rocm-6.1.2/include/hsa
-----HSA-Runtime-Lib: /opt/rocm-6.1.2/lib
----HSA_KMT_LIB_PATH: /opt/rocm-6.1.2/lib
----COMGR_LIB_PATH  : /opt/rocm-6.1.2/lib
-------ROCM_ROOT_DIR: /opt/rocm-6.1.2
-----CMAKE_CXX_FLAGS:  -std=c++2a -Wall -Werror -Wno-braced-scalar-init -Wno-unused-lambda-capture -Wno-unused-function -Wno-unused-variable -Wno-switch-bool -Wno-unused-private-field -Werror=return-type -fexceptions -fvisibility=hidden -fno-math-errno -fno-threadsafe-statics -fmerge-all-constants -fms-extensions -fmerge-all-constants -Werror=unused-result -fPIC -m64  -msse -msse2
---CMAKE_PREFIX_PATH: /opt/rocm
---------GPU_TARGETS: 
-- LIB-VERSION STRING: 1.0.0
/home1/colramos/GitHub/logduration
generate_hsaco: /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl gfx900
/home1/colramos/GitHub/logduration
generate_hsaco: /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl gfx906
/home1/colramos/GitHub/logduration
generate_hsaco: /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl gfx908
/home1/colramos/GitHub/logduration
generate_hsaco: /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl gfx90a
/home1/colramos/GitHub/logduration
generate_hsaco: /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl gfx942
/home1/colramos/GitHub/logduration
generate_hsaco: /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl gfx1030
/home1/colramos/GitHub/logduration
generate_hsaco: /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl gfx1031
/home1/colramos/GitHub/logduration
generate_hsaco: /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl gfx1032
/home1/colramos/GitHub/logduration
generate_hsaco: /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl gfx1100
/home1/colramos/GitHub/logduration
generate_hsaco: /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl gfx1101
/home1/colramos/GitHub/logduration
generate_hsaco: /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl gfx1102
/home1/colramos/GitHub/logduration/build/test_kernels/gfx900_copy.hsaco;/home1/colramos/GitHub/logduration/build/test_kernels/gfx906_copy.hsaco;/home1/colramos/GitHub/logduration/build/test_kernels/gfx908_copy.hsaco;/home1/colramos/GitHub/logduration/build/test_kernels/gfx90a_copy.hsaco;/home1/colramos/GitHub/logduration/build/test_kernels/gfx942_copy.hsaco;/home1/colramos/GitHub/logduration/build/test_kernels/gfx1030_copy.hsaco;/home1/colramos/GitHub/logduration/build/test_kernels/gfx1031_copy.hsaco;/home1/colramos/GitHub/logduration/build/test_kernels/gfx1032_copy.hsaco;/home1/colramos/GitHub/logduration/build/test_kernels/gfx1100_copy.hsaco;/home1/colramos/GitHub/logduration/build/test_kernels/gfx1101_copy.hsaco;/home1/colramos/GitHub/logduration/build/test_kernels/gfx1102_copy.hsaco
CMake-install-prefix: /
CPack-install-prefix: /
-----------Dest-name: logDuration
-- Configuring done
-- Generating done
-- Build files have been written to: /home1/colramos/GitHub/logduration/build
(base) [colramos@login1 build]$ make
/opt/ohpc/pub/utils/cmake/3.25.2/bin/cmake -S/home1/colramos/GitHub/logduration -B/home1/colramos/GitHub/logduration/build --check-build-system CMakeFiles/Makefile.cmake 0
/opt/ohpc/pub/utils/cmake/3.25.2/bin/cmake -E cmake_progress_start /home1/colramos/GitHub/logduration/build/CMakeFiles /home1/colramos/GitHub/logduration/build//CMakeFiles/progress.marks
make  -f CMakeFiles/Makefile2 all
make[1]: Entering directory '/home1/colramos/GitHub/logduration/build'
make  -f CMakeFiles/hsaco_targets.dir/build.make CMakeFiles/hsaco_targets.dir/depend
make[2]: Entering directory '/home1/colramos/GitHub/logduration/build'
cd /home1/colramos/GitHub/logduration/build && /opt/ohpc/pub/utils/cmake/3.25.2/bin/cmake -E cmake_depends "Unix Makefiles" /home1/colramos/GitHub/logduration /home1/colramos/GitHub/logduration /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/build/CMakeFiles/hsaco_targets.dir/DependInfo.cmake --color=
make[2]: Leaving directory '/home1/colramos/GitHub/logduration/build'
make  -f CMakeFiles/hsaco_targets.dir/build.make CMakeFiles/hsaco_targets.dir/build
make[2]: Entering directory '/home1/colramos/GitHub/logduration/build'
[  7%] /home1/colramos/GitHub/logduration/build/test_kernels/gfx900_copy.hsaco
cd /home1/colramos/GitHub/logduration/build/test_kernels && /opt/rocm-6.1.2/llvm/bin/clang -O2 -x cl -Xclang -finclude-default-header -cl-denorms-are-zero -cl-std=CL2.0 -Wl,--build-id=sha1 -target amdgcn-amd-amdhsa -mcpu=gfx900 -o gfx900_copy.hsaco /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl
[ 14%] /home1/colramos/GitHub/logduration/build/test_kernels/gfx906_copy.hsaco
cd /home1/colramos/GitHub/logduration/build/test_kernels && /opt/rocm-6.1.2/llvm/bin/clang -O2 -x cl -Xclang -finclude-default-header -cl-denorms-are-zero -cl-std=CL2.0 -Wl,--build-id=sha1 -target amdgcn-amd-amdhsa -mcpu=gfx906 -o gfx906_copy.hsaco /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl
[ 21%] /home1/colramos/GitHub/logduration/build/test_kernels/gfx908_copy.hsaco
cd /home1/colramos/GitHub/logduration/build/test_kernels && /opt/rocm-6.1.2/llvm/bin/clang -O2 -x cl -Xclang -finclude-default-header -cl-denorms-are-zero -cl-std=CL2.0 -Wl,--build-id=sha1 -target amdgcn-amd-amdhsa -mcpu=gfx908 -o gfx908_copy.hsaco /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl
[ 28%] /home1/colramos/GitHub/logduration/build/test_kernels/gfx90a_copy.hsaco
cd /home1/colramos/GitHub/logduration/build/test_kernels && /opt/rocm-6.1.2/llvm/bin/clang -O2 -x cl -Xclang -finclude-default-header -cl-denorms-are-zero -cl-std=CL2.0 -Wl,--build-id=sha1 -target amdgcn-amd-amdhsa -mcpu=gfx90a -o gfx90a_copy.hsaco /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl
[ 35%] /home1/colramos/GitHub/logduration/build/test_kernels/gfx942_copy.hsaco
cd /home1/colramos/GitHub/logduration/build/test_kernels && /opt/rocm-6.1.2/llvm/bin/clang -O2 -x cl -Xclang -finclude-default-header -cl-denorms-are-zero -cl-std=CL2.0 -Wl,--build-id=sha1 -target amdgcn-amd-amdhsa -mcpu=gfx942 -o gfx942_copy.hsaco /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl
[ 42%] /home1/colramos/GitHub/logduration/build/test_kernels/gfx1030_copy.hsaco
cd /home1/colramos/GitHub/logduration/build/test_kernels && /opt/rocm-6.1.2/llvm/bin/clang -O2 -x cl -Xclang -finclude-default-header -cl-denorms-are-zero -cl-std=CL2.0 -Wl,--build-id=sha1 -target amdgcn-amd-amdhsa -mcpu=gfx1030 -o gfx1030_copy.hsaco /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl
[ 50%] /home1/colramos/GitHub/logduration/build/test_kernels/gfx1031_copy.hsaco
cd /home1/colramos/GitHub/logduration/build/test_kernels && /opt/rocm-6.1.2/llvm/bin/clang -O2 -x cl -Xclang -finclude-default-header -cl-denorms-are-zero -cl-std=CL2.0 -Wl,--build-id=sha1 -target amdgcn-amd-amdhsa -mcpu=gfx1031 -o gfx1031_copy.hsaco /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl
[ 57%] /home1/colramos/GitHub/logduration/build/test_kernels/gfx1032_copy.hsaco
cd /home1/colramos/GitHub/logduration/build/test_kernels && /opt/rocm-6.1.2/llvm/bin/clang -O2 -x cl -Xclang -finclude-default-header -cl-denorms-are-zero -cl-std=CL2.0 -Wl,--build-id=sha1 -target amdgcn-amd-amdhsa -mcpu=gfx1032 -o gfx1032_copy.hsaco /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl
[ 64%] /home1/colramos/GitHub/logduration/build/test_kernels/gfx1100_copy.hsaco
cd /home1/colramos/GitHub/logduration/build/test_kernels && /opt/rocm-6.1.2/llvm/bin/clang -O2 -x cl -Xclang -finclude-default-header -cl-denorms-are-zero -cl-std=CL2.0 -Wl,--build-id=sha1 -target amdgcn-amd-amdhsa -mcpu=gfx1100 -o gfx1100_copy.hsaco /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl
[ 71%] /home1/colramos/GitHub/logduration/build/test_kernels/gfx1101_copy.hsaco
cd /home1/colramos/GitHub/logduration/build/test_kernels && /opt/rocm-6.1.2/llvm/bin/clang -O2 -x cl -Xclang -finclude-default-header -cl-denorms-are-zero -cl-std=CL2.0 -Wl,--build-id=sha1 -target amdgcn-amd-amdhsa -mcpu=gfx1101 -o gfx1101_copy.hsaco /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl
[ 78%] /home1/colramos/GitHub/logduration/build/test_kernels/gfx1102_copy.hsaco
cd /home1/colramos/GitHub/logduration/build/test_kernels && /opt/rocm-6.1.2/llvm/bin/clang -O2 -x cl -Xclang -finclude-default-header -cl-denorms-are-zero -cl-std=CL2.0 -Wl,--build-id=sha1 -target amdgcn-amd-amdhsa -mcpu=gfx1102 -o gfx1102_copy.hsaco /home1/colramos/GitHub/logduration/src/test_kernels/copy.cl
make[2]: Leaving directory '/home1/colramos/GitHub/logduration/build'
[ 78%] Built target hsaco_targets
make  -f CMakeFiles/logDuration64.dir/build.make CMakeFiles/logDuration64.dir/depend
make[2]: Entering directory '/home1/colramos/GitHub/logduration/build'
cd /home1/colramos/GitHub/logduration/build && /opt/ohpc/pub/utils/cmake/3.25.2/bin/cmake -E cmake_depends "Unix Makefiles" /home1/colramos/GitHub/logduration /home1/colramos/GitHub/logduration /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/build /home1/colramos/GitHub/logduration/build/CMakeFiles/logDuration64.dir/DependInfo.cmake --color=
make[2]: Leaving directory '/home1/colramos/GitHub/logduration/build'
make  -f CMakeFiles/logDuration64.dir/build.make CMakeFiles/logDuration64.dir/build
make[2]: Entering directory '/home1/colramos/GitHub/logduration/build'
[ 85%] Building CXX object CMakeFiles/logDuration64.dir/src/interceptor.cc.o
/bin/g++ -DAQLPROF_NEW_API=1 -DHSA_DEPRECATED="" -DHSA_LARGE_MODEL="" -DLINUX -DLITTLEENDIAN_CPU=1 -DNEW_TRACE_API=1 -DUNIX_OS -D__AMD64__ -D__linux__ -D__x86_64__ -DlogDuration64_EXPORTS -I/home1/colramos/GitHub/logduration/build -I/home1/colramos/GitHub/logduration/src -I/opt/rocm-6.1.2/include -I/home1/colramos/GitHub/logduration -I/opt/rocm-6.1.2/include/hsa -I/opt/rocm-6.1.2/lib/.. -std=c++2a -Wall -Werror -Wno-braced-scalar-init -Wno-unused-lambda-capture -Wno-unused-function -Wno-unused-variable -Wno-switch-bool -Wno-unused-private-field -Werror=return-type -fexceptions -fvisibility=hidden -fno-math-errno -fno-threadsafe-statics -fmerge-all-constants -fms-extensions -fmerge-all-constants -Werror=unused-result -fPIC -m64  -msse -msse2 -O3 -DNDEBUG -fPIC -std=gnu++20 -MD -MT CMakeFiles/logDuration64.dir/src/interceptor.cc.o -MF CMakeFiles/logDuration64.dir/src/interceptor.cc.o.d -o CMakeFiles/logDuration64.dir/src/interceptor.cc.o -c /home1/colramos/GitHub/logduration/src/interceptor.cc
[ 92%] Building CXX object CMakeFiles/logDuration64.dir/src/utils.cc.o
/bin/g++ -DAQLPROF_NEW_API=1 -DHSA_DEPRECATED="" -DHSA_LARGE_MODEL="" -DLINUX -DLITTLEENDIAN_CPU=1 -DNEW_TRACE_API=1 -DUNIX_OS -D__AMD64__ -D__linux__ -D__x86_64__ -DlogDuration64_EXPORTS -I/home1/colramos/GitHub/logduration/build -I/home1/colramos/GitHub/logduration/src -I/opt/rocm-6.1.2/include -I/home1/colramos/GitHub/logduration -I/opt/rocm-6.1.2/include/hsa -I/opt/rocm-6.1.2/lib/.. -std=c++2a -Wall -Werror -Wno-braced-scalar-init -Wno-unused-lambda-capture -Wno-unused-function -Wno-unused-variable -Wno-switch-bool -Wno-unused-private-field -Werror=return-type -fexceptions -fvisibility=hidden -fno-math-errno -fno-threadsafe-statics -fmerge-all-constants -fms-extensions -fmerge-all-constants -Werror=unused-result -fPIC -m64  -msse -msse2 -O3 -DNDEBUG -fPIC -std=gnu++20 -MD -MT CMakeFiles/logDuration64.dir/src/utils.cc.o -MF CMakeFiles/logDuration64.dir/src/utils.cc.o.d -o CMakeFiles/logDuration64.dir/src/utils.cc.o -c /home1/colramos/GitHub/logduration/src/utils.cc
[100%] Linking CXX shared library liblogDuration64.so
/opt/ohpc/pub/utils/cmake/3.25.2/bin/cmake -E cmake_link_script CMakeFiles/logDuration64.dir/link.txt --verbose=1
/bin/g++ -fPIC  -std=c++2a -Wall -Werror -Wno-braced-scalar-init -Wno-unused-lambda-capture -Wno-unused-function -Wno-unused-variable -Wno-switch-bool -Wno-unused-private-field -Werror=return-type -fexceptions -fvisibility=hidden -fno-math-errno -fno-threadsafe-statics -fmerge-all-constants -fms-extensions -fmerge-all-constants -Werror=unused-result -fPIC -m64  -msse -msse2 -O3 -DNDEBUG -Wl,-Bdynamic -Wl,-z,noexecstack -shared -Wl,-soname,liblogDuration64.so.1 -o liblogDuration64.so.1.0.0 CMakeFiles/logDuration64.dir/src/interceptor.cc.o CMakeFiles/logDuration64.dir/src/utils.cc.o   -L/opt/rocm-6.1.2/lib  -L/home1/colramos/.local/lib64  /opt/rocm-6.1.2/lib/libhsa-runtime64.so -lc -lstdc++ -lstdc++fs 
/opt/ohpc/pub/utils/cmake/3.25.2/bin/cmake -E cmake_symlink_library liblogDuration64.so.1.0.0 liblogDuration64.so.1 liblogDuration64.so
/bin/strip *.so
make[2]: Leaving directory '/home1/colramos/GitHub/logduration/build'
[100%] Built target logDuration64
make[1]: Leaving directory '/home1/colramos/GitHub/logduration/build'
/opt/ohpc/pub/utils/cmake/3.25.2/bin/cmake -E cmake_progress_start /home1/colramos/GitHub/logduration/build/CMakeFiles 0
```