### PR TITLE
Initialize device memory allocated by hsa_mem_mgr to zero.

### DIFF
--- a/inc/hsa_mem_mgr.h
+++ b/inc/hsa_mem_mgr.h
@@ -30,16 +30,15 @@ class hsa_mem_mgr : public dh_comms::dh_comms_mem_mgr
 public:
     hsa_mem_mgr(hsa_agent_t agent,const pool_specs_t& pool, const KernArgAllocator& allocator);
     virtual ~hsa_mem_mgr();
-    virtual void * alloc(std::size_t size);
-    virtual void free(void *);
-    virtual void free_device_memory(void *);
-    virtual void * copy(void *dst, void *src, std::size_t size);
-    virtual void * alloc_device_memory(std::size_t size);
-    virtual void * copy_to_device(void *dst, const void *src, std::size_t size);
+    virtual void * calloc(std::size_t size) override;
+    virtual void free(void *) override;
+    virtual void free_device_memory(void *) override;
+    virtual void * copy(void *dst, void *src, std::size_t size) override;
+    virtual void * calloc_device_memory(std::size_t size) override;
+    virtual void * copy_to_device(void *dst, const void *src, std::size_t size) override;
 private:
     hsa_agent_t agent_;
     const pool_specs_t pool_;
     const KernArgAllocator& allocator_;
 
 };
-

--- a/src/hsa_mem_mgr.cc
+++ b/src/hsa_mem_mgr.cc
@@ -29,14 +29,14 @@ hsa_mem_mgr::hsa_mem_mgr(hsa_agent_t agent, const pool_specs_t& pool, const Kern
     uint32_t length = sizeof(name);
     hsa_agent_get_info(pool.agent_, HSA_AGENT_INFO_NAME, name);
     //std::cerr << "AGENT NAME in hsa_mem_mgr: " << name << std::endl;
-    //std::cerr << "agent: " << std::hex << pool.agent_.handle << " pool: " << pool.pool_.handle << " min_alloc_size: " << std::dec << pool.min_alloc_size_ << std::endl; 
+    //std::cerr << "agent: " << std::hex << pool.agent_.handle << " pool: " << pool.pool_.handle << " min_alloc_size: " << std::dec << pool.min_alloc_size_ << std::endl;
 }
 
 hsa_mem_mgr::~hsa_mem_mgr()
 {
 }
 
-void * hsa_mem_mgr::alloc(std::size_t size)
+void * hsa_mem_mgr::calloc(std::size_t size)
 {
     void *result = allocator_.allocate(size, pool_.agent_);
     zero(result,size);
@@ -69,7 +69,7 @@ void * hsa_mem_mgr::copy_to_device(void *dst, const void *src, std::size_t size)
         throw std::exception();
 }
 
-void * hsa_mem_mgr::alloc_device_memory(std::size_t size)
+void * hsa_mem_mgr::calloc_device_memory(std::size_t size)
 {
     void *buffer = NULL;
     size_t mask = pool_.min_alloc_size_ - 1;
@@ -79,6 +79,6 @@ void * hsa_mem_mgr::alloc_device_memory(std::size_t size)
     hsa_status_t status = hsa_amd_memory_pool_allocate(pool_.pool_, adjusted_size, 0, &buffer);
     if (status != HSA_STATUS_SUCCESS)
         throw std::bad_alloc();
+    zero_device_memory(buffer, adjusted_size);
     return buffer;
 }
-


### PR DESCRIPTION
Allocated host-pinned memory was already zero-initialized, device memory was not. Base class dh_comms::dh_comms_mem_mgr now requires zero-initialization for correct functioning.

Other minor changes:
- changed names of 'alloc' and 'alloc_device_memory' to 'calloc' and 'calloc_device_memory' as a hint to programmers that these functions not only allocate, but also zero-initialize.
- added 'override' attribute to all virtual functions. Without the attribute, name changes in the base class virtual functions would still result in compilation of the derived class hsa_mem_mgr. The alloc functions in the latter now did not override the ones in the base class, but were new functions. When dh_comms would call the new calloc functions, it would use the ones defined in the base class, and inherited (but not overridden) in the derived class. So when logduration expects to use dh_comms with HSA-based allocation functions, it would use HIP-based allocation functions instead. The override attribute on the virtual functions protects against such silent errors: a name change in the base class now triggers a compiler error if the name isn't changed in the derived class too.