### PR TITLE
JSON support in MemoryAnalysis handler 

### DIFF
--- a/inc/memory_analysis_handler.h
+++ b/inc/memory_analysis_handler.h
@@ -95,6 +95,7 @@ private:
   bool handle_cache_line_count_analysis(const message_t &message);
   void report_cache_line_use();
   void report_bank_conflicts();
+  void report_json();
 
 private:
   //! Maps each of the supported memory access sizes to the conflict sets for that size

--- a/omniprobe/omniprobe
+++ b/omniprobe/omniprobe
@@ -36,6 +36,32 @@ from pyfiglet import figlet_format
 sys.stdout.reconfigure(line_buffering=True)
 
 
+def finalize_json_output(location, handlers):
+    """Finalize JSON output by adding closing bracket if needed (MemoryAnalysis plugin only)"""
+    if location == "console":
+        return
+        
+    # Check if MemoryAnalysis plugin is being used
+    using_memory_analysis = any("libMemAnalysis64.so" in handler for handler in handlers)
+    if not using_memory_analysis:
+        return
+        
+    # Check if JSON format is being used
+    if os.environ.get("LOGDUR_LOG_FORMAT") == "json":
+        try:
+            # Check if the file exists and has content
+            if os.path.exists(location) and os.path.getsize(location) > 0:
+                # Read the file to check if it starts with '[' (indicating it has JSON array content)
+                with open(location, "r") as f:
+                    content = f.read().strip()
+                    if content.startswith("["):
+                        # Append closing bracket to complete the JSON array
+                        with open(location, "a") as f:
+                            f.write("\n]")
+        except Exception as e:
+            print(f"Warning: Could not finalize JSON output: {e}")
+
+
 # Generate ASCII art for the word "omniprobe"
 name  = "Omniprobe"
 ascii_art = figlet_format(name, font="standard")  # Default font
@@ -635,6 +661,9 @@ def main():
     parms.handlers = handlers
     if len(parms.remaining) != 0 and not parms.dump_env == True:
         capture_subprocess_output(parms.remaining[1:], new_env=setup_env(parms))
+        # Finalize JSON output if needed
+        log_location = parms.log_location if parms.log_location else "console"
+        finalize_json_output(log_location, parms.handlers)
     elif parms.dump_env == True:
         setup_env(parms)
 

--- a/src/memory_analysis_handler.cc
+++ b/src/memory_analysis_handler.cc
@@ -736,6 +736,17 @@ std::string getCodeContext(const std::string &fname, uint16_t line) {
 void memory_analysis_handler_t::report_json() {
   std::stringstream json_output;
   
+  // Check if this is the first dispatch to write the opening bracket
+  bool is_first_dispatch = (dispatch_id_ == 1);
+  bool is_console_output = (location_ == "console");
+  
+  // Write opening bracket for first dispatch (but not for console output)
+  if (is_first_dispatch && !is_console_output) {
+    json_output << "[\n";
+  } else if (!is_first_dispatch) {
+    json_output << ",\n";
+  }
+  
   json_output << "{\n";
   json_output << "  \"kernel_analysis\": {\n";
   
@@ -881,10 +892,15 @@ void memory_analysis_handler_t::report_json() {
   json_output << "      \"cache_line_size\": " << cache_line_size << "\n";
   json_output << "    }\n";
   json_output << "  }\n";
-  json_output << "}\n";
+  json_output << "}";
+  
+  // Add newline for console output (for readability)
+  if (is_console_output) {
+    json_output << "\n";
+  }
   
   // Write to the log file
-  *log_file_ << json_output.str() << "\n";
+  *log_file_ << json_output.str();
 }
 
 } // namespace dh_comms


### PR DESCRIPTION
This PR is an iteration on #21 that instead logs MemoryAnalysis output in the logduration message handler. The plugin behaves same as before in most instances, however now when user provides `-t json` JSON output will print to console. Additionally, the user can specify a log file (e.g. `-l output.json`) to save this JSON structure to an output file for further post-processing.



<details>

<summary>Example usage:</summary>

```
root@51a53ca4a7c7:/workspace# logdur_install/bin/logDuration/omniprobe -i -a MemoryAnalysis -t json -- audacious/maestro/examples/build/bank_conflict/b2b_matrix_transpose 
  ___                  _                 _          
 / _ \ _ __ ___  _ __ (_)_ __  _ __ ___ | |__   ___ 
| | | | '_ ` _ \| '_ \| | '_ \| '__/ _ \| '_ \ / _ \
| |_| | | | | | | | | | | |_) | | | (_) | |_) |  __/
 \___/|_| |_| |_|_| |_|_| .__/|_|  \___/|_.__/ \___|
                        |_|                         

Found config file at /workspace/logdur_install/bin/logDuration/runtime_config.txt

Omniprobe is developed by Advanced Micro Devices, Research and Advanced Development
Copyright (c) 2025 Advanced Micro Devices. All rights reserved.

No Triton cache location provided; assuming HIP run.
HANDLER: libMemAnalysis64.so
Memory Analysis Wrapper loaded.
handlerManager: OpenedlibMemAnalysis64.so
Adding /workspace/audacious/maestro/examples/build/bank_conflict/b2b_matrix_transpose
Found 12 kernels
Adding linux-vdso.so.1
Adding /opt/rocm/lib/libamdhip64.so.6
Adding /lib/x86_64-linux-gnu/libstdc++.so.6
Adding /lib/x86_64-linux-gnu/libm.so.6
Adding /lib/x86_64-linux-gnu/libgcc_s.so.1
Adding /lib/x86_64-linux-gnu/libc.so.6
Adding /opt/rocm/lib/librocprofiler-register.so.0
Adding /opt/rocm/lib/libamd_comgr.so.2
Adding /opt/rocm/lib/libhsa-runtime64.so.1
Adding /lib/x86_64-linux-gnu/libnuma.so.1
Adding /lib64/ld-linux-x86-64.so.2
Adding /lib/x86_64-linux-gnu/libz.so.1
Adding /lib/x86_64-linux-gnu/libzstd.so.1
Adding /lib/x86_64-linux-gnu/libelf.so.1
Adding /opt/amdgpu/lib/x86_64-linux-gnu/libdrm.so.2
Adding /opt/amdgpu/lib/x86_64-linux-gnu/libdrm_amdgpu.so.1
Adding /workspace/logdur_install/lib/logDuration/liblogDuration64.so
Adding /workspace/logdur_install/lib/libdh_comms.so
Adding /workspace/logdur_install/lib/libkernelDB64.so.1
Adding /lib/x86_64-linux-gnu/libdwarf.so.1
Adding /workspace/logdur_install/lib/libMemAnalysis64.so
Adding /workspace/audacious/maestro/examples/build/bank_conflict/b2b_matrix_transpose
[...Removed for brevity...]
>>>>>>>> HSA intercept registered.
{
  "kernel_analyses": [
    {
      "kernel_info": {
        "name": "matrixTransposeShared_0(float*, float const*, int, int) [clone .kd]",
        "dispatch_id": 1
      },
      "cache_analysis": {
        "accesses": [
          {
            "source_location": {
              "file": "/workspace/audacious/maestro/examples/bank_conflict/b2b_matrix_transpose/b2b_matrix_transpose.hip",
              "line": 40,
              "column": 38
            },
            "code_context": "tile[threadIdx.y][threadIdx.x] = in[y * width + x];",
            "access_info": {
              "type": "read",
              "execution_count": 16384,
              "ir_bytes": 4,
              "isa_bytes": 4,
              "isa_instruction": "global_load_dword",
              "cache_lines": {
                "needed": 65536,
                "used": 65536
              }
            }
          },
          {
            "source_location": {
              "file": "/workspace/audacious/maestro/examples/bank_conflict/b2b_matrix_transpose/b2b_matrix_transpose.hip",
              "line": 49,
              "column": 25
            },
            "code_context": "out[y * height + x] = tile[threadIdx.x][threadIdx.y];",
            "access_info": {
              "type": "write",
              "execution_count": 16384,
              "ir_bytes": 4,
              "isa_bytes": 4,
              "isa_instruction": "global_store_dword",
              "cache_lines": {
                "needed": 65536,
                "used": 65536
              }
            }
          }
        ]
      },
      "bank_conflicts": {
        "accesses": [
          {
            "source_location": {
              "file": "/workspace/audacious/maestro/examples/bank_conflict/b2b_matrix_transpose/b2b_matrix_transpose.hip",
              "line": 40,
              "column": 36
            },
            "code_context": "tile[threadIdx.y][threadIdx.x] = in[y * width + x];",
            "access_info": {
              "type": "write",
              "execution_count": 16384,
              "ir_bytes": 4,
              "total_conflicts": 0
            }
          },
          {
            "source_location": {
              "file": "/workspace/audacious/maestro/examples/bank_conflict/b2b_matrix_transpose/b2b_matrix_transpose.hip",
              "line": 49,
              "column": 27
            },
            "code_context": "out[y * height + x] = tile[threadIdx.x][threadIdx.y];",
            "access_info": {
              "type": "read",
              "execution_count": 16384,
              "ir_bytes": 4,
              "total_conflicts": 229376
            }
          }
        ]
      }
    }
  ],
  "metadata": {
    "version": "null",
    "kernels_found": 1,
    "timestamp": "2025-06-30 17:00:30",
    "gpu_info": {
      "architecture": "gfx90a",
      "cache_line_size": 128
    }
  }
},
54525952 bytes processed in 1.878942 seconds (29.0 MiB/s)
{
  "kernel_analyses": [
    {
      "kernel_info": {
        "name": "matrixTransposeShared_1(float*, float const*, int, int) [clone .kd]",
        "dispatch_id": 2
      },
      "cache_analysis": {
        "accesses": [
          {
            "source_location": {
              "file": "/workspace/audacious/maestro/examples/bank_conflict/b2b_matrix_transpose/b2b_matrix_transpose.hip",
              "line": 63,
              "column": 38
            },
            "code_context": "tile[threadIdx.y][threadIdx.x] = in[y * width + x];",
            "access_info": {
              "type": "read",
              "execution_count": 16384,
              "ir_bytes": 4,
              "isa_bytes": 4,
              "isa_instruction": "global_load_dword",
              "cache_lines": {
                "needed": 65536,
                "used": 65536
              }
            }
          },
          {
            "source_location": {
              "file": "/workspace/audacious/maestro/examples/bank_conflict/b2b_matrix_transpose/b2b_matrix_transpose.hip",
              "line": 72,
              "column": 25
            },
            "code_context": "out[y * height + x] = tile[threadIdx.x][threadIdx.y];",
            "access_info": {
              "type": "write",
              "execution_count": 16384,
              "ir_bytes": 4,
              "isa_bytes": 4,
              "isa_instruction": "global_store_dword",
              "cache_lines": {
                "needed": 65536,
                "used": 65536
              }
            }
          }
        ]
      },
      "bank_conflicts": {
        "accesses": [
          {
            "source_location": {
              "file": "/workspace/audacious/maestro/examples/bank_conflict/b2b_matrix_transpose/b2b_matrix_transpose.hip",
              "line": 63,
              "column": 36
            },
            "code_context": "tile[threadIdx.y][threadIdx.x] = in[y * width + x];",
            "access_info": {
              "type": "write",
              "execution_count": 16384,
              "ir_bytes": 4,
              "total_conflicts": 0
            }
          },
          {
            "source_location": {
              "file": "/workspace/audacious/maestro/examples/bank_conflict/b2b_matrix_transpose/b2b_matrix_transpose.hip",
              "line": 72,
              "column": 27
            },
            "code_context": "out[y * height + x] = tile[threadIdx.x][threadIdx.y];",
            "access_info": {
              "type": "read",
              "execution_count": 16384,
              "ir_bytes": 4,
              "total_conflicts": 229376
            }
          }
        ]
      }
    }
  ],
  "metadata": {
    "version": "null",
    "kernels_found": 1,
    "timestamp": "2025-06-30 17:00:32",
    "gpu_info": {
      "architecture": "gfx90a",
      "cache_line_size": 128
    }
  }
}
54525952 bytes processed in 3.588229 seconds (15.2 MiB/s)
Memory Analysis Wrapper unloaded.
Comms Runner shutting down
Cache Watcher shutting down
```

</details>