### PR TITLE
Auto upload image to DockerHub

### DIFF
--- a/.github/workflows/docker-upload.yml
+++ b/.github/workflows/docker-upload.yml
@@ -1,0 +1,73 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [ main, colramos/docker-upload ]
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Read VERSION file
+        id: version
+        run: |
+          if [ -f VERSION ]; then
+            echo "version=$(cat VERSION)" >> $GITHUB_OUTPUT
+          else
+            # Fallback to git commit hash if VERSION file doesn't exist
+            echo "version=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build Docker image
+        run: |
+          # Build the Docker image using the existing build script
+          ./containers/build.sh --docker
+
+      - name: Tag image for DockerHub
+        run: |
+          # Get your DockerHub username from secrets
+          DOCKERHUB_USERNAME="${{ secrets.DOCKERHUB_USERNAME }}"
+          VERSION="${{ steps.version.outputs.version }}"
+          
+          # Tag the locally built image for DockerHub
+          docker tag omniprobe:${VERSION} ${DOCKERHUB_USERNAME}/omniprobe:${VERSION}
+          docker tag omniprobe:${VERSION} ${DOCKERHUB_USERNAME}/omniprobe:latest
+
+      - name: Push to DockerHub
+        run: |
+          DOCKERHUB_USERNAME="${{ secrets.DOCKERHUB_USERNAME }}"
+          VERSION="${{ steps.version.outputs.version }}"
+          
+          # Push both version tag and latest tag
+          docker push ${DOCKERHUB_USERNAME}/omniprobe:${VERSION}
+          docker push ${DOCKERHUB_USERNAME}/omniprobe:latest
+
+      - name: Image digest
+        run: |
+          DOCKERHUB_USERNAME="${{ secrets.DOCKERHUB_USERNAME }}"
+          VERSION="${{ steps.version.outputs.version }}"
+          echo "Image pushed: ${DOCKERHUB_USERNAME}/omniprobe:${VERSION}"
+          echo "Image pushed: ${DOCKERHUB_USERNAME}/omniprobe:latest" 

--- a/.github/workflows/docker-upload.yml
+++ b/.github/workflows/docker-upload.yml
@@ -16,6 +16,7 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false  # Don't cancel other builds if one fails
       matrix:
         rocm-version: ['6.3', '6.4']
     

--- a/.github/workflows/docker-upload.yml
+++ b/.github/workflows/docker-upload.yml
@@ -15,6 +15,9 @@ concurrency:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rocm-version: ['6.3', '6.4']
     
     steps:
       - name: Checkout code
@@ -44,30 +47,33 @@ jobs:
       - name: Build Docker image
         run: |
           # Build the Docker image using the existing build script
-          ./containers/build.sh --docker
+          ./containers/build.sh --docker --rocm ${{ matrix.rocm-version }}
 
       - name: Tag image for DockerHub
         run: |
           # Get your DockerHub username from secrets
           DOCKERHUB_USERNAME="${{ secrets.DOCKERHUB_USERNAME }}"
           VERSION="${{ steps.version.outputs.version }}"
+          ROCM_VERSION="${{ matrix.rocm-version }}"
           
-          # Tag the locally built image for DockerHub
-          docker tag omniprobe:${VERSION} ${DOCKERHUB_USERNAME}/omniprobe:${VERSION}
-          docker tag omniprobe:${VERSION} ${DOCKERHUB_USERNAME}/omniprobe:latest
+          # Tag the locally built image for DockerHub with multiple tags
+          docker tag omniprobe:${VERSION}-rocm${ROCM_VERSION} ${DOCKERHUB_USERNAME}/omniprobe:${VERSION}-rocm${ROCM_VERSION}
+          docker tag omniprobe:${VERSION}-rocm${ROCM_VERSION} ${DOCKERHUB_USERNAME}/omniprobe:latest-rocm${ROCM_VERSION}
 
       - name: Push to DockerHub
         run: |
           DOCKERHUB_USERNAME="${{ secrets.DOCKERHUB_USERNAME }}"
           VERSION="${{ steps.version.outputs.version }}"
+          ROCM_VERSION="${{ matrix.rocm-version }}"
           
-          # Push both version tag and latest tag
-          docker push ${DOCKERHUB_USERNAME}/omniprobe:${VERSION}
-          docker push ${DOCKERHUB_USERNAME}/omniprobe:latest
+          # Push version-specific and ROCm-specific tags
+          docker push ${DOCKERHUB_USERNAME}/omniprobe:${VERSION}-rocm${ROCM_VERSION}
+          docker push ${DOCKERHUB_USERNAME}/omniprobe:latest-rocm${ROCM_VERSION}
 
       - name: Image digest
         run: |
           DOCKERHUB_USERNAME="${{ secrets.DOCKERHUB_USERNAME }}"
           VERSION="${{ steps.version.outputs.version }}"
-          echo "Image pushed: ${DOCKERHUB_USERNAME}/omniprobe:${VERSION}"
-          echo "Image pushed: ${DOCKERHUB_USERNAME}/omniprobe:latest" 
+          ROCM_VERSION="${{ matrix.rocm-version }}"
+          echo "Image pushed: ${DOCKERHUB_USERNAME}/omniprobe:${VERSION}-rocm${ROCM_VERSION}"
+          echo "Image pushed: ${DOCKERHUB_USERNAME}/omniprobe:latest-rocm${ROCM_VERSION}" 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "external/dh_comms"]
 	path = external/dh_comms
-	url = git@github.com:AMDResearch/dh_comms.git
+	url = https://github.com/AMDResearch/dh_comms.git
 [submodule "external/kerneldb"]
 	path = external/kerneldb
-	url = git@github.com:AMDResearch/kerneldb.git
+	url = https://github.com/AMDResearch/kerneldb.git
 [submodule "external/instrument-amdgpu-kernels"]
 	path = external/instrument-amdgpu-kernels
-	url = git@github.com:AMDResearch/instrument-amdgpu-kernels.git
+	url = https://github.com/AMDResearch/instrument-amdgpu-kernels.git

--- a/README.md
+++ b/README.md
@@ -115,9 +115,13 @@ General omniprobe arguments:
 We provide containerized execution environments for users to get started with omniprobe right away. Leverage the [`containers/run.sh`](containers/run.sh) script to jump into a container with the project and all of its dependencies pre-installed. Use the `--docker` or `--apptainer` flags to build the image for your preferred container runtime.
 
 Example:
-```shell
-# Start container
-./docker/run.sh --docker # Or --apptainer depending on your preference
+```console
+$ ./containers/run.sh 
+Error: Must specify either --docker or --apptainer.
+Usage: ./containers/run.sh [--docker] [--apptainer] [--rocm VERSION]
+  --docker      Run using Docker container
+  --apptainer   Run using Apptainer container
+  --rocm        ROCm version (default: 6.3, supported: 6.3 6.4)
 ```
 
 That's it! If a container matching your detected [`VERSION`](VERSION) of omniprobe doesn't exist already, one will be built automatically.

--- a/containers/.dockerignore
+++ b/containers/.dockerignore
@@ -1,0 +1,61 @@
+# Git files
+.git
+.gitignore
+.gitmodules
+
+# Build artifacts
+build/
+*.o
+*.a
+*.so
+*.dylib
+*.dll
+
+# Documentation
+*.md
+README*
+CHANGELOG*
+LICENSE*
+CONTRIBUTING*
+docs/
+
+# IDE/Editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Python cache
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+.pytest_cache/
+
+# Container files (exclude specific files but keep triton_install.sh)
+containers/omniprobe.Dockerfile
+containers/omniprobe.def
+containers/build.sh
+containers/run.sh
+containers/.dockerignore
+containers/*.sif
+# Note: triton_install.sh is intentionally NOT excluded as it's needed for the build
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Temporary files
+*.tmp
+*.temp
+*.log
+
+# Development/testing files
+.env
+.env.local
+.env.*.local
+test/
+tests/
+*_test.py
+*_test.cpp 

--- a/containers/build.sh
+++ b/containers/build.sh
@@ -84,7 +84,7 @@ if [ "$build_apptainer" = true ]; then
     # Build the Apptainer container with ROCm version
     export ROCM_VERSION="$rocm_version"
     apptainer build \
-      "${name}_$(cat "$parent_dir/VERSION")-rocm${rocm_version}.sif" "$script_dir/omniprobe.def"
+      "${script_dir}/${name}_$(cat "$parent_dir/VERSION")-rocm${rocm_version}.sif" "$script_dir/omniprobe.def"
 
     echo "Apptainer build complete!"
 fi

--- a/containers/build.sh
+++ b/containers/build.sh
@@ -13,6 +13,9 @@ build_docker=false
 build_apptainer=false
 rocm_version="6.3"  # Default ROCm version
 
+# Supported ROCm versions
+supported_rocm_versions=("6.3" "6.4")
+
 while [[ $# -gt 0 ]]; do
   case $1 in
     --apptainer)
@@ -35,12 +38,19 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Validate ROCm version
+if [[ ! " ${supported_rocm_versions[@]} " =~ " ${rocm_version} " ]]; then
+    echo "Error: Unsupported ROCm version '$rocm_version'"
+    echo "Supported ROCm versions: ${supported_rocm_versions[*]}"
+    exit 1
+fi
+
 if [ "$build_docker" = false ] && [ "$build_apptainer" = false ]; then
     echo "Error: At least one of the options --docker or --apptainer is required."
     echo "Usage: $0 [--docker] [--apptainer] [--rocm VERSION]"
     echo "  --docker      Build Docker container"
     echo "  --apptainer   Build Apptainer container"
-    echo "  --rocm        ROCm version (default: 6.3)"
+    echo "  --rocm        ROCm version (default: 6.3, supported: ${supported_rocm_versions[*]})"
     exit 1
 fi
 

--- a/containers/build.sh
+++ b/containers/build.sh
@@ -36,27 +36,15 @@ if [ "$build_docker" = false ] && [ "$build_apptainer" = false ]; then
     exit 1
 fi
 
-pushd "$script_dir"
-  
+pushd "$parent_dir"
+
 if [ "$build_docker" = true ]; then
     echo "Building Docker container..."
-    
-    # Auto-configure SSH agent
-    if [ ! -S ~/.ssh/ssh_auth_sock ]; then
-      eval "$(ssh-agent)" > /dev/null
-      ln -sf "$SSH_AUTH_SOCK" ~/.ssh/ssh_auth_sock
-    fi
-    export SSH_AUTH_SOCK=~/.ssh/ssh_auth_sock
-
-    # Add default keys if they exist
-    [ -f ~/.ssh/id_rsa ] && ssh-add ~/.ssh/id_rsa
-    [ -f ~/.ssh/id_ed25519 ] && ssh-add ~/.ssh/id_ed25519
-    [ -f ~/.ssh/id_github ] && ssh-add ~/.ssh/id_github
+    git submodule update --init --recursive $parent_dir
 
     # Enable BuildKit and build the Docker image
     export DOCKER_BUILDKIT=1
     docker build \
-        --ssh default \
         -t "$name:$(cat "$parent_dir/VERSION")" \
         -f "$script_dir/omniprobe.Dockerfile" \
         .

--- a/containers/build.sh
+++ b/containers/build.sh
@@ -73,6 +73,7 @@ fi
 
 if [ "$build_apptainer" = true ]; then
     echo "Building Apptainer container with ROCm $rocm_version..."
+    git submodule update --init --recursive $parent_dir
 
     # Check if apptainer is installed
     if ! command -v apptainer &> /dev/null; then

--- a/containers/build.sh
+++ b/containers/build.sh
@@ -82,8 +82,8 @@ if [ "$build_apptainer" = true ]; then
     fi
 
     # Build the Apptainer container with ROCm version
-    export ROCM_VERSION="$rocm_version"
     apptainer build \
+      --build-arg ROCM_VERSION="$rocm_version" \
       "${script_dir}/${name}_$(cat "$parent_dir/VERSION")-rocm${rocm_version}.sif" "$script_dir/omniprobe.def"
 
     echo "Apptainer build complete!"

--- a/containers/omniprobe.Dockerfile
+++ b/containers/omniprobe.Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 
-FROM rocm/rocm-build-ubuntu-22.04:6.3
+ARG ROCM_VERSION=6.3
+FROM rocm/rocm-build-ubuntu-22.04:${ROCM_VERSION}
 LABEL Description="Docker container for LOGDURATION" 
 WORKDIR /app
 
@@ -17,7 +18,6 @@ RUN apt-get update && \
 # =========================
 # ROCm install
 # =========================
-ARG ROCM_VERSION=6.3
 RUN ROCM_MAJOR=$(echo ${ROCM_VERSION} | sed 's/\./ /g' | awk '{print $1}') && \
     ROCM_MINOR=$(echo ${ROCM_VERSION} | sed 's/\./ /g' | awk '{print $2}') && \
     ROCM_VERSN=$(( (${ROCM_MAJOR}*10000)+(${ROCM_MINOR}*100) )) && \

--- a/containers/omniprobe.Dockerfile
+++ b/containers/omniprobe.Dockerfile
@@ -4,8 +4,6 @@ FROM rocm/rocm-build-ubuntu-22.04:6.3
 LABEL Description="Docker container for LOGDURATION" 
 WORKDIR /app
 
-COPY triton_install.sh /app/triton_install.sh
-
 # =========================
 # Dependencies install
 # =========================
@@ -35,9 +33,15 @@ ENV ROCM_PATH=/opt/rocm
 ENV LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}
 
 # =========================
+# Copy project files 
+# =========================
+COPY ../ /app/omniprobe
+WORKDIR /app/omniprobe
+
+# =========================
 # Triton install
 # =========================
-RUN  bash -c "source /app/triton_install.sh -g 368c864e9"
+RUN  bash -c "source /app/omniprobe/containers/triton_install.sh -g 368c864e9"
 
 ENV TRITON_HIP_LDD_PATH=${ROCM_PATH}/llvm/bin/ld.lld
 ENV TRITON_LLVM=/root/.triton/llvm/llvm-7ba6768d-ubuntu-x64
@@ -46,18 +50,8 @@ ENV PATH=/app/triton/.venv/bin:${PATH}
 # =========================
 # logduration install
 # =========================
-RUN mkdir -p ~/.ssh && \
-    touch ~/.ssh/known_hosts && \
-    ssh-keyscan github.com >> ~/.ssh/known_hosts && \
-    chmod 700 ~/.ssh && \
-    chmod 644 ~/.ssh/known_hosts
 
-RUN --mount=type=ssh \
-    cd /app && \
-    git clone git@github.com:AMDResearch/omniprobe.git && \
-    cd omniprobe && \
-    git submodule update --init --recursive && \
-    python3 -m pip install -r omniprobe/requirements.txt && \
+RUN python3 -m pip install -r omniprobe/requirements.txt && \
     mkdir -p /opt/logduration && \
     cmake --version && \
     mkdir -p build && \

--- a/containers/omniprobe.Dockerfile
+++ b/containers/omniprobe.Dockerfile
@@ -54,6 +54,7 @@ ENV PATH=/app/triton/.venv/bin:${PATH}
 RUN python3 -m pip install -r omniprobe/requirements.txt && \
     mkdir -p /opt/logduration && \
     cmake --version && \
+    rm -rf build && \
     mkdir -p build && \
     cmake -DCMAKE_INSTALL_PREFIX=/opt/logduration -DCMAKE_PREFIX_PATH=${ROCM_PATH} -DTRITON_LLVM=${TRITON_LLVM} -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON -S . -B build && \
     cmake --build build --target install

--- a/containers/omniprobe.Dockerfile
+++ b/containers/omniprobe.Dockerfile
@@ -17,8 +17,8 @@ RUN apt-get update && \
 # =========================
 # ROCm install
 # =========================
-RUN ROCM_VERSION="6.3" && \
-    ROCM_MAJOR=$(echo ${ROCM_VERSION} | sed 's/\./ /g' | awk '{print $1}') && \
+ARG ROCM_VERSION=6.3
+RUN ROCM_MAJOR=$(echo ${ROCM_VERSION} | sed 's/\./ /g' | awk '{print $1}') && \
     ROCM_MINOR=$(echo ${ROCM_VERSION} | sed 's/\./ /g' | awk '{print $2}') && \
     ROCM_VERSN=$(( (${ROCM_MAJOR}*10000)+(${ROCM_MINOR}*100) )) && \
     echo "ROCM_MAJOR=${ROCM_MAJOR} ROCM_MINOR=${ROCM_MINOR} ROCM_VERSN=${ROCM_VERSN}" && \

--- a/containers/omniprobe.def
+++ b/containers/omniprobe.def
@@ -34,7 +34,7 @@ From: rocm/rocm-build-ubuntu-22.04:6.3
     python3 -m pip install --upgrade setuptools 
     
     # ROCm install 
-    ROCM_VERSION="6.3" 
+    ROCM_VERSION="${ROCM_VERSION:-6.3}"  # Use environment variable or default to 6.3
     ROCM_MAJOR=$(echo ${ROCM_VERSION} | sed 's/\./ /g' | awk '{print $1}') 
     ROCM_MINOR=$(echo ${ROCM_VERSION} | sed 's/\./ /g' | awk '{print $2}') 
     ROCM_VERSN=$(( (${ROCM_MAJOR}*10000)+(${ROCM_MINOR}*100) )) 

--- a/containers/omniprobe.def
+++ b/containers/omniprobe.def
@@ -12,8 +12,7 @@ From: rocm/rocm-build-ubuntu-22.04:6.3
     export TRITON_LLVM=/root/.triton/llvm/llvm-7ba6768d-ubuntu-x64 
 
 %files 
-    ../../omniprobe /app/omniprobe
-    triton_install.sh /app
+    . /app/omniprobe
 
 %post 
     # Set globals
@@ -45,15 +44,8 @@ From: rocm/rocm-build-ubuntu-22.04:6.3
     apt-get install -y rocm-dev${ROCM_VERSION} rocm-llvm-dev${ROCM_VERSION} rocm-hip-runtime-dev${ROCM_VERSION} rocm-smi-lib${ROCM_VERSION} rocminfo${ROCM_VERSION} 
     
     # Triton install 
-    ls /app
-    bash -c "source /app/triton_install.sh -g 368c864e9" 
-    
-    # Logduration install 
-    mkdir -p ~/.ssh 
-    touch ~/.ssh/known_hosts 
-    ssh-keyscan github.com >> ~/.ssh/known_hosts 
-    chmod 700 ~/.ssh 
-    chmod 644 ~/.ssh/known_hosts 
+    ls /app/omniprobe
+    bash -c "source /app/omniprobe/containers/triton_install.sh -g 368c864e9"
     
     cd /app 
     ls

--- a/containers/omniprobe.def
+++ b/containers/omniprobe.def
@@ -1,5 +1,8 @@
 Bootstrap: docker 
-From: rocm/rocm-build-ubuntu-22.04:6.3 
+From: rocm/rocm-build-ubuntu-22.04:{{ ROCM_VERSION }}
+
+%arguments
+    ROCM_VERSION=6.3
 
 %labels 
     Description "Apptainer container for LOGDURATION" 
@@ -33,7 +36,7 @@ From: rocm/rocm-build-ubuntu-22.04:6.3
     python3 -m pip install --upgrade setuptools 
     
     # ROCm install 
-    ROCM_VERSION="${ROCM_VERSION:-6.3}"  # Use environment variable or default to 6.3
+    ROCM_VERSION= {{ ROCM_VERSION }}
     ROCM_MAJOR=$(echo ${ROCM_VERSION} | sed 's/\./ /g' | awk '{print $1}') 
     ROCM_MINOR=$(echo ${ROCM_VERSION} | sed 's/\./ /g' | awk '{print $2}') 
     ROCM_VERSN=$(( (${ROCM_MAJOR}*10000)+(${ROCM_MINOR}*100) )) 

--- a/containers/omniprobe.def
+++ b/containers/omniprobe.def
@@ -36,7 +36,7 @@ From: rocm/rocm-build-ubuntu-22.04:{{ ROCM_VERSION }}
     python3 -m pip install --upgrade setuptools 
     
     # ROCm install 
-    ROCM_VERSION= {{ ROCM_VERSION }}
+    ROCM_VERSION={{ ROCM_VERSION }}
     ROCM_MAJOR=$(echo ${ROCM_VERSION} | sed 's/\./ /g' | awk '{print $1}') 
     ROCM_MINOR=$(echo ${ROCM_VERSION} | sed 's/\./ /g' | awk '{print $2}') 
     ROCM_VERSN=$(( (${ROCM_MAJOR}*10000)+(${ROCM_MINOR}*100) )) 

--- a/containers/run.sh
+++ b/containers/run.sh
@@ -15,6 +15,9 @@ use_docker=false
 use_apptainer=false
 rocm_version="6.3"  # Default ROCm version
 
+# Supported ROCm versions
+supported_rocm_versions=("6.3" "6.4")
+
 while [[ $# -gt 0 ]]; do
   case $1 in
     --docker)
@@ -37,6 +40,13 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Validate ROCm version
+if [[ ! " ${supported_rocm_versions[@]} " =~ " ${rocm_version} " ]]; then
+    echo "Error: Unsupported ROCm version '$rocm_version'"
+    echo "Supported ROCm versions: ${supported_rocm_versions[*]}"
+    exit 1
+fi
+
 # Validate arguments
 if [ "$use_docker" = true ] && [ "$use_apptainer" = true ]; then
     echo "Error: Cannot use both --docker and --apptainer simultaneously."
@@ -47,7 +57,7 @@ elif [ "$use_docker" = false ] && [ "$use_apptainer" = false ]; then
     echo "Usage: $0 [--docker] [--apptainer] [--rocm VERSION]"
     echo "  --docker      Run using Docker container"
     echo "  --apptainer   Run using Apptainer container"
-    echo "  --rocm        ROCm version (default: 6.3)"
+    echo "  --rocm        ROCm version (default: 6.3, supported: ${supported_rocm_versions[*]})"
     exit 1
 fi
 


### PR DESCRIPTION
Creating a mechanism to auto build omniprobe and publish container to DockerHub, triggered on pushes to `main`. In order to do this, I had to add some more fine grain controls to the `containers/run.sh` build script. Now, you can use `--rocm` to control the ROCm version installed in your container. So now we'll have 6.3 and 6.4 compatible images pushed to DockerHub, e.g.

```
# For ROCm 6.3
docker pull audacioussw/omniprobe:latest-rocm6.3

# For ROCm 6.4
docker pull audacioussw/omniprobe:latest-rocm6.4

# For specific version with ROCm
docker pull audacioussw/omniprobe:1.0.0-rocm6.3
docker pull audacioussw/omniprobe:1.0.0-rocm6.4
```

The issue is that the project is too large to build in default GitHub runner environment, so we'll need a public-safe self hosted runner to make this action go live... Marking this as a TODO for now