### PR TITLE
Patch JSON output with kernel filter, MemoryAnalysis plugin

### DIFF
--- a/containers/omniprobe.Dockerfile
+++ b/containers/omniprobe.Dockerfile
@@ -2,6 +2,7 @@
 
 ARG ROCM_VERSION=6.3
 FROM rocm/rocm-build-ubuntu-22.04:${ROCM_VERSION}
+ARG ROCM_VERSION=6.3 
 LABEL Description="Docker container for LOGDURATION" 
 WORKDIR /app
 

--- a/omniprobe/omniprobe
+++ b/omniprobe/omniprobe
@@ -58,6 +58,11 @@ def finalize_json_output(location, handlers):
                         # Append closing bracket to complete the JSON array
                         with open(location, "a") as f:
                             f.write("\n]")
+                    elif content.startswith("{") and not content.endswith("]"):
+                        # Handle single JSON object case (like with kernel filtering)
+                        # Wrap it in an array for consistency
+                        with open(location, "w") as f:
+                            f.write("[\n" + content + "\n]")
         except Exception as e:
             print(f"Warning: Could not finalize JSON output: {e}")
 

--- a/src/memory_analysis_handler.cc
+++ b/src/memory_analysis_handler.cc
@@ -867,28 +867,39 @@ void memory_analysis_handler_t::report_json() {
   std::string arch = "unknown";
   int cache_line_size = 128; // default
   
-  hipDeviceProp_t props;
-  hipError_t err = hipGetDeviceProperties(&props, 0);
-  if (err == hipSuccess) {
-    std::string gcnArchName_str(props.gcnArchName);
-    size_t colon_pos = gcnArchName_str.find(':');
-    if (colon_pos != std::string::npos) {
-      arch = gcnArchName_str.substr(0, colon_pos);
-    } else {
-      arch = gcnArchName_str;
-    }
+  // In case of kernel filtering, multiple dispatches may processed sequentially, causing multiple calls to this hipGetDeviceProperties()
+  // Found that this race condition causes HIP call to hang.
+  // Check if this is JSON output with kernel filtering - if so, skip HIP call that hangs
+  const char* kernelFilter = std::getenv("LOGDUR_FILTER");
+  bool hasKernelFilter = (kernelFilter && strlen(kernelFilter) > 0);
 
-    std::map<std::string, int> arch_to_cache_size = {
-        {"gfx906", 64},
-        {"gfx908", 64},
-        {"gfx90a", 128},
-        {"gfx940", 128},
-        {"gfx941", 128},
-        {"gfx942", 128}
-    };
+  if (hasKernelFilter) {
+    std::cout << "DEBUG: Skipping GPU properties query for JSON output with kernel filtering to avoid contention" << std::endl;
+    std::cout << "DEBUG: Using default GPU info: arch='" << arch << "', cache_line_size=" << cache_line_size << std::endl;
+  } else {
+    hipDeviceProp_t props;
+    hipError_t err = hipGetDeviceProperties(&props, 0);
+    if (err == hipSuccess) {
+      std::string gcnArchName_str(props.gcnArchName);
+      size_t colon_pos = gcnArchName_str.find(':');
+      if (colon_pos != std::string::npos) {
+        arch = gcnArchName_str.substr(0, colon_pos);
+      } else {
+        arch = gcnArchName_str;
+      }
 
-    if (arch_to_cache_size.count(arch)) {
-        cache_line_size = arch_to_cache_size[arch];
+      std::map<std::string, int> arch_to_cache_size = {
+          {"gfx906", 64},
+          {"gfx908", 64},
+          {"gfx90a", 128},
+          {"gfx940", 128},
+          {"gfx941", 128},
+          {"gfx942", 128}
+      };
+
+      if (arch_to_cache_size.count(arch)) {
+          cache_line_size = arch_to_cache_size[arch];
+      }
     }
   }
 


### PR DESCRIPTION
Upon testing JSON output support in the MemoryAnalysis plugin I found empty output that would only occur while using the kernel filtering option in omniprobe (i.e. `-k`/`--kernels`). The bug occurred because when kernel filtering is used, Omniprobe could process multiple dispatches at a time, which I'm guessing caused a race condition between multiple handler instances. The easiest solution is to skip the metadata output in this case, which solved the issue for me.

This PR also patches an issue in ROCm install in Docker container build where ROCM_VERSION build arg needed to be declared after FROM statement in the Dockerfile for correct scoping. This fixed the issue.