### PR TITLE
tests: resolve native library paths via ldd for distro portability

### DIFF
--- a/tests/run_library_filter_tests.sh
+++ b/tests/run_library_filter_tests.sh
@@ -98,6 +98,21 @@ if [ -x "$MEMORY_ANALYSIS_TEST" ]; then
     echo "Library Filter Tests"
     echo "================================================================================"
 
+    # Resolve native library paths from the test binary's own linkage.
+    # Architecture-agnostic: ldd returns the paths the dynamic linker
+    # would actually use for this binary, regardless of distro layout.
+    LIBM_PATH=$(ldd "$MEMORY_ANALYSIS_TEST" 2>/dev/null \
+        | awk '$1 ~ /^libm\.so/{print $3; exit}')
+    if [ -z "$LIBM_PATH" ] || [ ! -e "$LIBM_PATH" ]; then
+        echo -e "${RED}ERROR: Could not resolve libm.so path from ${MEMORY_ANALYSIS_TEST}${NC}" >&2
+        echo "  ldd output:" >&2
+        ldd "$MEMORY_ANALYSIS_TEST" 2>&1 | sed 's/^/    /' >&2
+        exit 1
+    fi
+    NATIVE_LIB_DIR=$(dirname "$LIBM_PATH")
+    LIBCRYPT_PATH=$(ls "${NATIVE_LIB_DIR}"/libcrypt.so.* 2>/dev/null \
+        | head -1)
+
     # Test: Baseline - exclude non-existent library (should PASS, no behavior change)
     run_library_filter_test "libfilter_exclude_nonexistent" \
         "$MEMORY_ANALYSIS_TEST" \
@@ -105,17 +120,17 @@ if [ -x "$MEMORY_ANALYSIS_TEST" ]; then
         "present" \
         "libm.so"
 
-    # Test: Exclude /lib64/libm.so.6 (should NOT appear in "Adding" output)
+    # Test: Exclude libm (should NOT appear in "Adding" output)
     run_library_filter_test "libfilter_exclude_libm" \
         "$MEMORY_ANALYSIS_TEST" \
-        '{"exclude": ["/lib64/libm.so.6"]}' \
+        "{\"exclude\": [\"${LIBM_PATH}\"]}" \
         "absent" \
         "libm.so"
 
     # Test: Include a file that wouldn't normally be scanned
     run_library_filter_test "libfilter_include_extra" \
         "$MEMORY_ANALYSIS_TEST" \
-        '{"include": ["/lib64/libcrypt.so.2"]}' \
+        "{\"include\": [\"${LIBCRYPT_PATH}\"]}" \
         "present" \
         "libcrypt.so"
 


### PR DESCRIPTION
## Summary

`tests/run_library_filter_tests.sh` previously hardcoded `/lib64/libm.so.6`
and `/lib64/libcrypt.so.2`. These paths only exist on RHEL-family layouts;
on Debian/Ubuntu native libraries live under `/lib/x86_64-linux-gnu/`,
causing `libfilter_exclude_libm` to report libm as still being instrumented
and `libfilter_include_extra` to fail because the path does not exist.

This PR resolves the libm path at runtime via `ldd` against the test
binary, which uses the dynamic linker's actual resolution and is
independent of distro layout. The libcrypt path is derived from the same
directory.

An early-exit check is included so any failure to resolve libm produces a
clear error message rather than running tests with empty filter paths.

## Test plan

Verified on Ubuntu 24.04 / gfx908:
- `libfilter_exclude_nonexistent`: PASS (baseline, unchanged behavior)
- `libfilter_exclude_libm`: PASS (was FAIL before)
- `libfilter_include_extra`: PASS (was FAIL before)

On RHEL-family systems where `/lib64/` is the correct prefix, `ldd`
returns the same paths, so behavior is unchanged.

## Note

On gfx908 (MI100), `tests/run_library_filter_tests.sh` cannot currently
be reached on `main` because `getBitcodePath()` defaults to `_cdna2`
bitcode for non-`gfx94x`/`gfx90a` archs, causing the test to hang on
`libfilter_exclude_nonexistent`. This is an independent issue and a
companion fix will follow once this PR lands.