### PR TITLE
fix: select arch-specific bitcode for non-cdna3 architectures

### DIFF
--- a/src/instrumentation/InstrumentationCommon.cpp
+++ b/src/instrumentation/InstrumentationCommon.cpp
@@ -106,9 +106,22 @@ std::string getBitcodePath(const llvm::Module &M) {
     arch = "unknown";
   }
 
+  // Architecture -> bitcode suffix mapping. Must match the bitcode
+  // variants emitted by dh_comms (see dh_comms/CMakeLists.txt):
+  //   gfx94x      -> _cdna3 (legacy bundled bitcode)
+  //   gfx90a      -> _cdna2 (legacy bundled bitcode)
+  //   other gfx*  -> _<arch> per-arch bitcode (e.g. gfx908 -> _gfx908)
+  //   unknown     -> warn and best-effort fall back to _cdna2
   if (arch == "gfx940" || arch == "gfx941" || arch == "gfx942") {
     CDNAVersion = "_cdna3";
+  } else if (arch == "gfx90a") {
+    CDNAVersion = "_cdna2";
+  } else if (arch.size() >= 3 && arch.substr(0, 3) == "gfx") {
+    CDNAVersion = "_" + arch;
   } else {
+    llvm::errs() << "Warning: architecture '" << arch
+                 << "' has no matching bitcode. "
+                 << "Falling back to cdna2.\n";
     CDNAVersion = "_cdna2";
   }
 

--- a/tests/test_kernels/CMakeLists.txt
+++ b/tests/test_kernels/CMakeLists.txt
@@ -19,14 +19,29 @@ set(INST_PLUGIN "${CMAKE_BINARY_DIR}/lib/plugins/libAMDGCNSubmitAddressMessages-
 set(DH_COMMS_LIB_DIR "${CMAKE_BINARY_DIR}/external/dh_comms/lib")
 set(BITCODE_DIR "${CMAKE_BINARY_DIR}/lib/bitcode")
 
+# Build the list of bitcode files to copy (must mirror dh_comms/CMakeLists.txt)
+set(BITCODE_COPY_FILES
+    ${DH_COMMS_LIB_DIR}/dh_comms_dev_cdna2_co5.bc
+    ${DH_COMMS_LIB_DIR}/dh_comms_dev_cdna2_co6.bc
+    ${DH_COMMS_LIB_DIR}/dh_comms_dev_cdna3_co5.bc
+    ${DH_COMMS_LIB_DIR}/dh_comms_dev_cdna3_co6.bc
+)
+foreach(ARCH IN LISTS CMAKE_HIP_ARCHITECTURES)
+    # Strip arch features such as ":xnack+" so the resulting filename
+    # (e.g. dh_comms_dev_gfx908_co5.bc) matches what dh_comms emits.
+    string(REGEX REPLACE ":.*$" "" ARCH_BASE "${ARCH}")
+    list(APPEND BITCODE_COPY_FILES
+        ${DH_COMMS_LIB_DIR}/dh_comms_dev_${ARCH_BASE}_co5.bc
+        ${DH_COMMS_LIB_DIR}/dh_comms_dev_${ARCH_BASE}_co6.bc
+    )
+endforeach()
+list(REMOVE_DUPLICATES BITCODE_COPY_FILES)
+
 # Copy all bitcode files to build/lib/bitcode/
 add_custom_target(copy_bitcode ALL
     COMMAND ${CMAKE_COMMAND} -E make_directory ${BITCODE_DIR}
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${DH_COMMS_LIB_DIR}/dh_comms_dev_cdna2_co5.bc
-        ${DH_COMMS_LIB_DIR}/dh_comms_dev_cdna3_co5.bc
-        ${DH_COMMS_LIB_DIR}/dh_comms_dev_cdna2_co6.bc
-        ${DH_COMMS_LIB_DIR}/dh_comms_dev_cdna3_co6.bc
+        ${BITCODE_COPY_FILES}
         ${BITCODE_DIR}/
     DEPENDS dh_comms_bc
     COMMENT "Copying bitcode files to build/lib/bitcode/"


### PR DESCRIPTION
## Summary

`InstrumentationCommon.cpp::getBitcodePath()` previously selected `_cdna3`
bitcode for gfx94x architectures and fell through to `_cdna2` for everything
else. On gfx908 (MI100) this caused the loader to attach cdna2-built device
bitcode to a cdna1 dispatch, manifesting as the instrumented kernel hanging
on first execution.

This PR:

- Adds explicit handling for `gfx90a` (cdna2)
- Adds a generic fallback that maps any `gfxNNN` to per-arch bitcode
  (e.g., `gfx908 -> _gfx908`), matching the per-arch bitcode now emitted
  by dh_comms (https://github.com/AMDResearch/dh_comms/pull/18)
- Emits a warning to `llvm::errs()` and falls back to `_cdna2` for
  unrecognized architectures, preserving previous best-effort behaviour
- Updates `tests/test_kernels/CMakeLists.txt` to build `BITCODE_COPY_FILES`
  dynamically from `CMAKE_HIP_ARCHITECTURES` so the per-arch bitcode is
  copied for the target architecture; legacy cdna2/cdna3 files are still
  copied for backward compatibility

## Test plan

Verified on gfx908 (MI100):

- Before this PR: `run_handler_tests.sh` and `run_library_filter_tests.sh`
  hang on the first instrumented dispatch.
- After this PR: both suites run to completion, with `run_handler_tests.sh`
  passing TESTS 1–13.

`libfilter_exclude_libm` (TEST 14) and `libfilter_include_extra` (TEST 15)
still fail on this branch due to a separate pre-existing issue with
hardcoded library paths in `run_library_filter_tests.sh` (the failure was
previously hidden by the hang). That issue is fixed in companion PR
#<F2_PR_NUM>.

## Compatibility

- gfx94x: behaviour unchanged (still `_cdna3`)
- gfx90a: behaviour unchanged (`_cdna2`, was previously hit by the generic
  else branch)
- gfx908: now loads `_gfx908` bitcode (was incorrectly loading `_cdna2`)
- Other gfx*: now loads per-arch bitcode if dh_comms produces it,
  otherwise warns and falls back to `_cdna2`