### PR TITLE
fix: apply kernel name filter (-k) to runtime-discovered kernels

### DIFF
--- a/src/interceptor.cc
+++ b/src/interceptor.cc
@@ -958,10 +958,32 @@ void hsaInterceptor::addKernel(uint64_t kernelObject, std::string& name, hsa_exe
    // Register runtime-discovered kernels in the cache so that
    // findInstrumentedAlternative() can find them without --library-filter.
    // Skip registration for kernels from excluded files to respect the library filter.
+   // Also apply the kernel name filter (-k / LOGDUR_FILTER) here to mirror the
+   // check in coCache::addFile(); without it, runtime discovery re-introduces
+   // filtered-out kernels (and their instrumented clones) into lookup_map_,
+   // causing them to be instrumented despite the filter.
    if (run_instrumented_ &&
        !(library_filter_.isActive() &&
          kernel_cache_.isKernelFromExcludedFile(kernelObject, library_filter_)))
+   {
+       const std::string& strFilter = config_["LOGDUR_FILTER"];
+       if (strFilter.size())
+       {
+           try
+           {
+               std::regex filter_regex(strFilter, std::regex_constants::ECMAScript);
+               if (!std::regex_search(thisName, filter_regex))
+                   return;
+           }
+           catch (const std::regex_error& error)
+           {
+               std::cout << "ERROR: There is a problem with your kernel filter (\"" << strFilter << "\"):\n";
+               std::cout << "\t" << error.what() << std::endl;
+               abort();
+           }
+       }
        kernel_cache_.registerRuntimeKernel(thisName, symbol, kernelObject, agent, kernarg_size);
+   }
 }
 
 hsa_status_t hsaInterceptor::hsa_executable_symbol_get_info(hsa_executable_symbol_t symbol, hsa_executable_symbol_info_t attribute, void *data)

--- a/tests/run_module_load_tests.sh
+++ b/tests/run_module_load_tests.sh
@@ -143,5 +143,73 @@ else
     TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 
+################################################################################
+# Test: kernel name filter (-k / LOGDUR_FILTER) excludes runtime-discovered
+#       kernels.
+#
+# Without the fix, runtime-discovered kernels bypass the kernel name filter
+# and get instrumented anyway. With the fix, the filter is applied uniformly
+# between coCache::addFile() and hsaInterceptor::addKernel().
+################################################################################
+
+TESTS_RUN=$((TESTS_RUN + 1))
+TEST_NAME="module_load_kernel_filter_excludes"
+echo -e "\n${YELLOW}[TEST $TESTS_RUN]${NC} $TEST_NAME"
+echo "  Run with -k regex that excludes module_load_kernel"
+echo "  Expect: instrumented alternative NOT used"
+
+OUTPUT_FILE="$OUTPUT_DIR/${TEST_NAME}.out"
+
+ROCR_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES" \
+    LD_LIBRARY_PATH="${OMNIPROBE_ROOT}/lib:${LD_LIBRARY_PATH}" \
+    "$OMNIPROBE" -i -a Heatmap \
+    --library-filter "$FILTER_FILE" \
+    -k "this_kernel_does_not_match_anything" \
+    -- "$MODULE_LOAD_TEST" "$MODULE_LOAD_HSACO" > "$OUTPUT_FILE" 2>&1 \
+    && run_ok=true || run_ok=true
+
+if grep -q "Found instrumented alternative for module_load_kernel" "$OUTPUT_FILE"; then
+    echo -e "  ${RED}✗ FAIL${NC} - Kernel was instrumented despite -k filter"
+    grep -E "instrumented alternative" "$OUTPUT_FILE" || true
+    echo "  Output saved to: $OUTPUT_FILE"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+else
+    echo -e "  ${GREEN}✓ PASS${NC} - Kernel correctly excluded by -k filter"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+fi
+
+################################################################################
+# Test: kernel name filter (-k) INCLUDES the runtime-discovered kernel.
+#
+# Sanity check: a -k regex matching the kernel name should NOT prevent
+# instrumentation. Guards against accidentally over-filtering in addKernel().
+################################################################################
+
+TESTS_RUN=$((TESTS_RUN + 1))
+TEST_NAME="module_load_kernel_filter_includes"
+echo -e "\n${YELLOW}[TEST $TESTS_RUN]${NC} $TEST_NAME"
+echo "  Run with -k regex that matches module_load_kernel"
+echo "  Expect: instrumented alternative used"
+
+OUTPUT_FILE="$OUTPUT_DIR/${TEST_NAME}.out"
+
+ROCR_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES" \
+    LD_LIBRARY_PATH="${OMNIPROBE_ROOT}/lib:${LD_LIBRARY_PATH}" \
+    "$OMNIPROBE" -i -a Heatmap \
+    --library-filter "$FILTER_FILE" \
+    -k "module_load_kernel" \
+    -- "$MODULE_LOAD_TEST" "$MODULE_LOAD_HSACO" > "$OUTPUT_FILE" 2>&1 \
+    && run_ok=true || run_ok=true
+
+if grep -q "Found instrumented alternative for module_load_kernel" "$OUTPUT_FILE"; then
+    echo -e "  ${GREEN}✓ PASS${NC} - Kernel correctly included by -k filter"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    echo -e "  ${RED}✗ FAIL${NC} - Kernel NOT instrumented despite matching -k filter"
+    grep -E "instrumented alternative" "$OUTPUT_FILE" || true
+    echo "  Output saved to: $OUTPUT_FILE"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
 # Export updated counters for parent script
 export TESTS_RUN TESTS_PASSED TESTS_FAILED


### PR DESCRIPTION
## Summary

`coCache::addFile()` applies the `LOGDUR_FILTER` regex (set via `-k` /
`--kernels`) when scanning shared libraries for kernels. However, kernels
loaded at runtime through `hipModuleLoad` reach
`hsaInterceptor::addKernel()` directly, bypassing the filter. As a
result, kernels excluded by `-k` still get instrumented if they were
loaded dynamically — defeating the purpose of the filter for applications
that use `hipModuleLoad`.

This PR mirrors the filter logic in `addKernel()` before calling
`registerRuntimeKernel()`. Behaviour is now consistent between the two
kernel-discovery code paths.

## Test plan

Two regression tests added to `tests/run_module_load_tests.sh`,
reusing the existing `module_load_test` host binary and
`module_load_kernel.hsaco` build artefacts:

- `module_load_kernel_filter_excludes`: a `-k` regex that does not
  match the kernel name must prevent instrumentation. Without this fix,
  the kernel was instrumented despite the filter.
- `module_load_kernel_filter_includes`: a `-k` regex that matches the
  kernel name must still allow instrumentation. Sanity check against
  over-filtering.

Verified on gfx908 (MI100): all module-load tests (TESTS 1–5) pass.

## Note

If you reproduce on MI100, you will also need companion PR
#38, which fixes a separate cdna1 bitcode-loading bug that
otherwise causes any instrumented kernel to hang on first dispatch.