### PR TITLE
Adds NUMA manager to allow memory allocation on specific NUMA node

### DIFF
--- a/inc/numa_mem_mgr.h
+++ b/inc/numa_mem_mgr.h
@@ -1,0 +1,57 @@
+/******************************************************************************
+Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*******************************************************************************/
+#pragma once
+
+#include <unordered_map>
+#include "inc/hsa_mem_mgr.h"
+
+/**
+ * Memory manager that places dh_comms shared buffers on a specific NUMA
+ * node (e.g., CXL-attached memory).  Inherits from hsa_mem_mgr so that
+ * GPU device-memory operations (calloc_device_memory, copy_to_device,
+ * free_device_memory) are unchanged.
+ *
+ * Only calloc() and free() are overridden: host-visible shared buffers
+ * are allocated via libnuma and registered with HIP for GPU access.
+ *
+ * Activate by setting env var OMNIPROBE_NUMA_NODE=<node_id>.
+ * Set OMNIPROBE_NUMA_VERBOSE=1 to log per-allocation placement
+ * (actual vs. requested NUMA node) for diagnostics.
+ */
+class numa_mem_mgr : public hsa_mem_mgr
+{
+public:
+    numa_mem_mgr(int numa_node,
+                 hsa_agent_t agent,
+                 const pool_specs_t& pool,
+                 const KernArgAllocator& allocator);
+    virtual ~numa_mem_mgr();
+
+    virtual void* calloc(std::size_t size) override;
+    virtual void  free(void* ptr) override;
+    virtual void  free_device_memory(void* ptr) override;
+
+private:
+    int  numa_node_;
+    bool verbose_;
+    std::unordered_map<void*, std::size_t> alloc_sizes_;
+};

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ set ( LIB_SRC
   ${LIB_DIR}/interceptor.cc
   ${LIB_DIR}/utils.cc
   ${LIB_DIR}/hsa_mem_mgr.cc
+  ${LIB_DIR}/numa_mem_mgr.cc
   ${LIB_DIR}/comms_mgr.cc
   ${LIB_DIR}/pyHandler.cc
   ${LIB_DIR}/memory_heatmap.cc
@@ -89,6 +90,13 @@ message("${HSACO_TARGET_LIST}")
 add_custom_target(hsaco_targets DEPENDS ${HSACO_TARGET_LIST})
 
 
+# libnuma is required by numa_mem_mgr for NUMA-pinned shared buffers
+# (activated at runtime via OMNIPROBE_NUMA_NODE).  Fail at configure time with
+# a clear message if libnuma-dev / numactl-devel is missing, rather than
+# emitting a cryptic linker error later.
+find_library(NUMA_LIBRARY NAMES numa REQUIRED)
+find_path(NUMA_INCLUDE_DIR NAMES numa.h numaif.h REQUIRED)
+
 link_directories(${ROCM_ROOT_DIR}/lib $ENV{HOME}/.local/lib64 ${CMAKE_INSTALL_PREFIX}/lib .)
 add_library ( ${TARGET_LIB} SHARED ${LIB_SRC})
 set_target_properties(${TARGET_LIB} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -105,6 +113,7 @@ target_include_directories (
     ${DH_COMMS_INCLUDE_DIR}
     ${CMAKE_INSTALL_PREFIX}/include
     ${Python_INCLUDE_DIRS}
+    ${NUMA_INCLUDE_DIR}
 )
 
 target_link_libraries(
@@ -118,6 +127,7 @@ target_link_libraries(
     kernelDB64
     amd_comgr
     elf
+    ${NUMA_LIBRARY}
     rocprofiler-sdk::rocprofiler-sdk
 )
 

--- a/src/comms_mgr.cc
+++ b/src/comms_mgr.cc
@@ -21,8 +21,11 @@ THE SOFTWARE.
 *******************************************************************************/
 #include "inc/comms_mgr.h"
 #include "inc/hsa_mem_mgr.h"
+#include "inc/numa_mem_mgr.h"
 #include "inc/memory_heatmap.h"
 #include "inc/time_interval_handler.h"
+
+#include <cstdlib>
 
 comms_mgr::comms_mgr(HsaApiTable *pTable) : kern_arg_allocator_(pTable, std::cerr), pTable_(pTable)
 {
@@ -144,9 +147,32 @@ bool comms_mgr::addAgent(hsa_agent_t agent)
 
     if (pools.size())
     {
+        const char* numa_env = std::getenv("OMNIPROBE_NUMA_NODE");
         for (auto item : pools)
         {
-            hsa_mem_mgr * mgr = new hsa_mem_mgr(item.agent_, item, kern_arg_allocator_);
+            dh_comms::dh_comms_mem_mgr* mgr;
+            if (numa_env) {
+                int node = std::atoi(numa_env);
+                // numa_mem_mgr throws on invalid node id or libnuma
+                // failure.  This call site runs inside an HSA agent
+                // enumeration path where exceptions get swallowed by
+                // the C runtime, leaving the process to exit cleanly
+                // with no instrumentation -- a confusing silent
+                // failure.  Catch explicitly and abort so the
+                // misconfiguration is immediately visible.
+                try {
+                    mgr = new numa_mem_mgr(node, item.agent_, item,
+                                           kern_arg_allocator_);
+                } catch (const std::exception& e) {
+                    std::cerr << "comms_mgr: failed to create "
+                              << "numa_mem_mgr: " << e.what()
+                              << " - aborting" << std::endl;
+                    std::abort();
+                }
+            } else {
+                mgr = new hsa_mem_mgr(item.agent_, item,
+                                      kern_arg_allocator_);
+            }
             mem_mgrs_[item.agent_] = mgr;
         }
     }

--- a/src/numa_mem_mgr.cc
+++ b/src/numa_mem_mgr.cc
@@ -1,0 +1,153 @@
+/******************************************************************************
+Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*******************************************************************************/
+#include "inc/numa_mem_mgr.h"
+
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <numa.h>
+#include <numaif.h>
+#include <hip/hip_runtime.h>
+
+numa_mem_mgr::numa_mem_mgr(int numa_node,
+                           hsa_agent_t agent,
+                           const pool_specs_t& pool,
+                           const KernArgAllocator& allocator)
+    : hsa_mem_mgr(agent, pool, allocator),
+      numa_node_(numa_node),
+      verbose_(std::getenv("OMNIPROBE_NUMA_VERBOSE") != nullptr)
+{
+    if (numa_available() < 0) {
+        std::cerr << "numa_mem_mgr: libnuma not available on this system"
+                  << std::endl;
+        throw std::runtime_error("libnuma not available");
+    }
+
+    if (numa_node_ < 0 || numa_node_ > numa_max_node()) {
+        std::cerr << "numa_mem_mgr: invalid NUMA node " << numa_node_
+                  << " (max=" << numa_max_node() << ")" << std::endl;
+        throw std::runtime_error("invalid NUMA node");
+    }
+
+    long long node_size = numa_node_size64(numa_node_, nullptr);
+    std::cerr << "numa_mem_mgr: targeting NUMA node " << numa_node_
+              << " (" << (node_size >> 20) << " MB)" << std::endl;
+}
+
+numa_mem_mgr::~numa_mem_mgr()
+{
+    for (auto& [ptr, size] : alloc_sizes_) {
+        hipHostUnregister(ptr);
+        numa_free(ptr, size);
+    }
+    alloc_sizes_.clear();
+}
+
+void* numa_mem_mgr::calloc(std::size_t size)
+{
+    void* ptr = numa_alloc_onnode(size, numa_node_);
+    if (!ptr) {
+        std::cerr << "numa_mem_mgr: numa_alloc_onnode(" << size << ", "
+                  << numa_node_ << ") failed" << std::endl;
+        throw std::bad_alloc();
+    }
+
+    memset(ptr, 0, size);
+
+    unsigned long nodemask = 1UL << numa_node_;
+    long ret = mbind(ptr, size, MPOL_BIND, &nodemask,
+                     sizeof(nodemask) * 8 + 1,
+                     MPOL_MF_STRICT | MPOL_MF_MOVE);
+    if (ret != 0) {
+        std::cerr << "numa_mem_mgr: mbind failed (errno=" << errno << ")"
+                  << std::endl;
+        numa_free(ptr, size);
+        throw std::runtime_error("mbind failed");
+    }
+
+    // Self-verification: query the actual node the first page landed on.
+    // The preceding memset faulted in the buffer and mbind with
+    // MPOL_MF_STRICT | MPOL_MF_MOVE forced placement, so move_pages should
+    // return a valid node id rather than -ENOENT.  Gated behind
+    // OMNIPROBE_NUMA_VERBOSE because allocations can be frequent and we
+    // do not want unconditional per-buffer log noise on production paths.
+    if (verbose_) {
+        void* pages[1] = {ptr};
+        int actual_node = -1;
+        if (move_pages(0, 1, pages, nullptr, &actual_node, 0) == 0) {
+            std::cerr << "numa_mem_mgr: allocated " << ptr
+                      << " size=" << size << " on node " << actual_node
+                      << " (requested " << numa_node_ << ")" << std::endl;
+        }
+    }
+
+    hipError_t err = hipHostRegister(ptr, size, hipHostRegisterMapped);
+    if (err != hipSuccess) {
+        std::cerr << "numa_mem_mgr: hipHostRegister failed ("
+                  << hipGetErrorString(err) << ")" << std::endl;
+        numa_free(ptr, size);
+        throw std::runtime_error("hipHostRegister failed");
+    }
+
+    void* gpu_ptr = nullptr;
+    err = hipHostGetDevicePointer(&gpu_ptr, ptr, 0);
+    if (err != hipSuccess || gpu_ptr != ptr) {
+        std::cerr << "numa_mem_mgr: GPU pointer mismatch "
+                  << "(host=" << ptr << " gpu=" << gpu_ptr << ")"
+                  << std::endl;
+        hipHostUnregister(ptr);
+        numa_free(ptr, size);
+        throw std::runtime_error("GPU pointer != host pointer");
+    }
+
+    alloc_sizes_[ptr] = size;
+    return ptr;
+}
+
+void numa_mem_mgr::free(void* ptr)
+{
+    auto it = alloc_sizes_.find(ptr);
+    if (it == alloc_sizes_.end()) {
+        hsa_mem_mgr::free_device_memory(ptr);
+        return;
+    }
+    // NUMA allocations are deferred to the destructor. hipHostUnregister()
+    // requires GPU idle, but free() can be called from the signal callback
+    // before ensure_shutdown() drains pending HSA completion signals.
+}
+
+void numa_mem_mgr::free_device_memory(void* ptr)
+{
+    auto it = alloc_sizes_.find(ptr);
+    if (it != alloc_sizes_.end()) {
+        // A NUMA-owned host buffer can reach free_device_memory() as well as
+        // free() depending on how dh_comms classifies the allocation it is
+        // releasing.  Treat both paths identically: defer cleanup to the
+        // destructor for the reason documented in free() above (HIP host
+        // unregister requires GPU idle, which is not guaranteed when this
+        // is invoked from a completion-signal callback).
+        return;
+    }
+
+    hsa_mem_mgr::free_device_memory(ptr);
+}

--- a/tests/run_handler_tests.sh
+++ b/tests/run_handler_tests.sh
@@ -43,5 +43,8 @@ source "${SCRIPT_DIR}/run_scope_filter_tests.sh"
 # Module-load kernel discovery tests (hipModuleLoad .hsaco)
 source "${SCRIPT_DIR}/run_module_load_tests.sh"
 
+# NUMA memory manager tests (OMNIPROBE_NUMA_NODE)
+source "${SCRIPT_DIR}/run_numa_tests.sh"
+
 # Print summary
 print_summary

--- a/tests/run_numa_tests.sh
+++ b/tests/run_numa_tests.sh
@@ -1,0 +1,228 @@
+#!/bin/bash
+################################################################################
+# NUMA memory manager tests for omniprobe.
+#
+# Verifies the env-var-gated NUMA memory manager (OMNIPROBE_NUMA_NODE):
+#   numa_default      - env unset, default behavior unchanged (no NUMA logs)
+#   numa_node_0       - env=0, manager invoked; on multi-node systems,
+#                       move_pages self-verification confirms placement
+#   numa_invalid_node - env=999, invalid-node guard raises an error
+#
+# Reuses simple_heatmap_test as the workload because it is the smallest
+# instrumented kernel that exercises dh_comms shared-buffer allocation.
+################################################################################
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/test_common.sh"
+
+check_omniprobe
+
+################################################################################
+# Locate test binary
+################################################################################
+
+HEATMAP_TEST="${BUILD_DIR}/tests/test_kernels/simple_heatmap_test"
+
+if [ ! -x "$HEATMAP_TEST" ]; then
+    echo -e "${YELLOW}SKIP: NUMA tests require simple_heatmap_test (${HEATMAP_TEST})${NC}"
+    export TESTS_RUN TESTS_PASSED TESTS_FAILED
+    return 0 2>/dev/null || exit 0
+fi
+
+################################################################################
+# Topology detection
+#
+# numa_default and numa_invalid_node only need libnuma loadable at runtime
+# (the library handles single-node systems gracefully).  numa_node_0 only
+# needs node 0 to exist, which is true on every NUMA-capable system.  The
+# placement assertion in numa_node_0 is skipped on single-node systems
+# because move_pages will always return node 0 there, making the test
+# tautological rather than a real check.
+################################################################################
+
+if command -v numactl >/dev/null 2>&1; then
+    NUMA_NODES=$(numactl --hardware | awk '/^available:/ {print $2}')
+else
+    NUMA_NODES=$(ls -d /sys/devices/system/node/node* 2>/dev/null | wc -l)
+fi
+
+if ! ldconfig -p 2>/dev/null | grep -q 'libnuma\.so'; then
+    echo -e "${YELLOW}SKIP: libnuma not found on this system${NC}"
+    export TESTS_RUN TESTS_PASSED TESTS_FAILED
+    return 0 2>/dev/null || exit 0
+fi
+
+if [ -z "$NUMA_NODES" ] || [ "$NUMA_NODES" -lt 1 ]; then
+    echo -e "${YELLOW}SKIP: No NUMA nodes detected${NC}"
+    export TESTS_RUN TESTS_PASSED TESTS_FAILED
+    return 0 2>/dev/null || exit 0
+fi
+
+echo ""
+echo "================================================================================"
+echo "NUMA Memory Manager Tests"
+echo "================================================================================"
+echo "  Test kernel : $HEATMAP_TEST"
+echo "  NUMA nodes  : $NUMA_NODES"
+echo "================================================================================"
+
+################################################################################
+# Test: numa_default - default behavior unchanged (env var unset)
+################################################################################
+
+TESTS_RUN=$((TESTS_RUN + 1))
+TEST_NAME="numa_default"
+echo -e "\n${YELLOW}[TEST $TESTS_RUN]${NC} $TEST_NAME"
+echo "  Run without OMNIPROBE_NUMA_NODE - expect default mem manager (no NUMA logs)"
+
+OUTPUT_FILE="$OUTPUT_DIR/${TEST_NAME}.out"
+
+if ROCR_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES" \
+   env -u OMNIPROBE_NUMA_NODE \
+   "$OMNIPROBE" -i -a Heatmap -- "$HEATMAP_TEST" > "$OUTPUT_FILE" 2>&1; then
+    if ! grep -q '^numa_mem_mgr:' "$OUTPUT_FILE"; then
+        echo -e "  ${GREEN}PASS${NC} - Default path used, no numa_mem_mgr output"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "  ${RED}FAIL${NC} - numa_mem_mgr output present with env unset"
+        grep '^numa_mem_mgr:' "$OUTPUT_FILE" | head -3 || true
+        echo "  Output saved to: $OUTPUT_FILE"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+else
+    echo -e "  ${RED}FAIL${NC} - Kernel execution failed"
+    echo "  Output saved to: $OUTPUT_FILE"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+################################################################################
+# Test: numa_node_0 - manager invoked, placement verified where possible
+#
+# OMNIPROBE_NUMA_VERBOSE=1 is required for the per-allocation "allocated ...
+# on node X (requested 0)" lines that the placement assertion grep'es for.
+# Without it the manager runs but emits only the one-shot "targeting NUMA
+# node 0" line from the constructor.
+################################################################################
+
+TESTS_RUN=$((TESTS_RUN + 1))
+TEST_NAME="numa_node_0"
+echo -e "\n${YELLOW}[TEST $TESTS_RUN]${NC} $TEST_NAME"
+echo "  OMNIPROBE_NUMA_NODE=0 - expect manager invoked + placement on node 0"
+
+OUTPUT_FILE="$OUTPUT_DIR/${TEST_NAME}.out"
+
+if ROCR_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES" \
+   OMNIPROBE_NUMA_NODE=0 \
+   OMNIPROBE_NUMA_VERBOSE=1 \
+   "$OMNIPROBE" -i -a Heatmap -- "$HEATMAP_TEST" > "$OUTPUT_FILE" 2>&1; then
+
+    invocation_ok=false
+    placement_ok=true
+
+    if grep -q "numa_mem_mgr: targeting NUMA node 0" "$OUTPUT_FILE"; then
+        invocation_ok=true
+    fi
+
+    if [ "$NUMA_NODES" -gt 1 ]; then
+        # Multi-node: every allocated... line must report node 0
+        alloc_lines=$(grep -c "numa_mem_mgr: allocated " "$OUTPUT_FILE" || true)
+        if [ "$alloc_lines" -eq 0 ]; then
+            placement_ok=false
+            placement_reason="no 'allocated' lines emitted (move_pages may have failed)"
+        else
+            mismatches=$(grep "numa_mem_mgr: allocated " "$OUTPUT_FILE" |
+                         grep -vE 'on node 0 \(requested 0\)' |
+                         wc -l)
+            if [ "$mismatches" -ne 0 ]; then
+                placement_ok=false
+                placement_reason="$mismatches allocation(s) landed off node 0"
+            fi
+        fi
+    else
+        echo "  [INFO] single-node system: skipping placement assertion"
+    fi
+
+    if [ "$invocation_ok" = true ] && [ "$placement_ok" = true ]; then
+        if [ "$NUMA_NODES" -gt 1 ]; then
+            echo -e "  ${GREEN}PASS${NC} - Manager invoked and placement verified on node 0"
+        else
+            echo -e "  ${GREEN}PASS${NC} - Manager invoked (placement assertion skipped: single-node)"
+        fi
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        if [ "$invocation_ok" != true ]; then
+            echo -e "  ${RED}FAIL${NC} - 'targeting NUMA node 0' not in output"
+        fi
+        if [ "$placement_ok" != true ]; then
+            echo -e "  ${RED}FAIL${NC} - placement check: ${placement_reason}"
+            grep "numa_mem_mgr:" "$OUTPUT_FILE" | head -10 || true
+        fi
+        echo "  Output saved to: $OUTPUT_FILE"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+else
+    echo -e "  ${RED}FAIL${NC} - Kernel execution failed with OMNIPROBE_NUMA_NODE=0"
+    echo "  Output saved to: $OUTPUT_FILE"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+################################################################################
+# Test: numa_invalid_node - constructor rejects out-of-range node, comms_mgr
+# catches and aborts.
+#
+# Contract is verified via two stderr messages (both must be present):
+#   1. "numa_mem_mgr: invalid NUMA node 999" - constructor validation fires
+#   2. "failed to create numa_mem_mgr ... aborting" - comms_mgr try/catch
+#      reached std::abort()
+#
+# Process exit code is informational, not asserted: the omniprobe Python
+# wrapper (omniprobe/omniprobe::capture_subprocess_output) currently does
+# not propagate child exit codes, so SIGABRT from the child surfaces as
+# exit 0 to the harness.  Tracked as a separate follow-up; when that fix
+# lands this test will start observing exit != 0 automatically.
+################################################################################
+
+TESTS_RUN=$((TESTS_RUN + 1))
+TEST_NAME="numa_invalid_node"
+echo -e "\n${YELLOW}[TEST $TESTS_RUN]${NC} $TEST_NAME"
+echo "  OMNIPROBE_NUMA_NODE=999 - expect constructor rejection + abort diagnostic in stderr"
+
+OUTPUT_FILE="$OUTPUT_DIR/${TEST_NAME}.out"
+
+run_exit=0
+ROCR_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES" OMNIPROBE_NUMA_NODE=999 \
+    "$OMNIPROBE" -i -a Heatmap -- "$HEATMAP_TEST" > "$OUTPUT_FILE" 2>&1 || run_exit=$?
+
+ctor_ok=false
+abort_ok=false
+grep -q "numa_mem_mgr: invalid NUMA node" "$OUTPUT_FILE" && ctor_ok=true
+grep -q "failed to create numa_mem_mgr.*aborting" "$OUTPUT_FILE" && abort_ok=true
+
+if [ "$ctor_ok" = true ] && [ "$abort_ok" = true ]; then
+    if [ "$run_exit" -ne 0 ]; then
+        echo -e "  ${GREEN}PASS${NC} - Invalid node rejected and process aborted (exit=$run_exit)"
+    else
+        echo -e "  ${YELLOW}[WARN]${NC} omniprobe wrapper masked the abort exit code (known issue)"
+        echo -e "  ${GREEN}PASS${NC} - Invalid node rejected: both diagnostic messages present in stderr"
+    fi
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    echo -e "  ${RED}FAIL${NC} - Expected diagnostic messages not all present:"
+    if [ "$ctor_ok" = true ]; then
+        echo "    constructor 'invalid NUMA node': found"
+    else
+        echo "    constructor 'invalid NUMA node': MISSING"
+    fi
+    if [ "$abort_ok" = true ]; then
+        echo "    'failed to create ... aborting': found"
+    else
+        echo "    'failed to create ... aborting': MISSING"
+    fi
+    echo "  exit=$run_exit"
+    echo "  Output saved to: $OUTPUT_FILE"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+export TESTS_RUN TESTS_PASSED TESTS_FAILED


### PR DESCRIPTION
## Summary

Introduces `numa_mem_mgr`, an `hsa_mem_mgr` subclass that pins the HSA
host buffers used by `dh_comms` (kernel<->host messaging) to a
caller-specified NUMA node. Avoids cross-socket traffic when an
instrumented kernel runs on a GPU bound to a specific socket.

When `OMNIPROBE_NUMA_NODE` is unset, the existing `hsa_mem_mgr` is used
and default behavior is unchanged.

## Behavior

- `OMNIPROBE_NUMA_NODE=<n>` — allocate `dh_comms` host buffers on node `<n>`.
- `OMNIPROBE_NUMA_VERBOSE=1` — emit one stderr line per allocation
  showing requested vs. actual placement.
- `mbind()` with `MPOL_BIND | MPOL_MF_STRICT | MPOL_MF_MOVE` on every
  allocation; `move_pages` self-verification so silent misses surface at
  runtime rather than as performance regressions.
- Invalid node values are caught at the `comms_mgr` level and surfaced
  via `std::abort` with a stderr diagnostic. The HSA agent-enumeration
  path swallows C++ exceptions, so without this catch a misconfiguration
  would degrade silently to no-instrumentation.

## Build

CMake locates `libnuma` via `find_library` + `find_path` and fails at
configure time with a clear message if the library or headers are
missing.

## Test plan

`tests/run_numa_tests.sh` (wired into `run_handler_tests.sh`) covers:

1. `numa_default` — no env var, default path, no NUMA logs.
2. `numa_node_0` — `OMNIPROBE_NUMA_NODE=0`, asserts manager invoked and
   per-allocation `move_pages` verification places buffers on node 0.
3. `numa_invalid_node` — `OMNIPROBE_NUMA_NODE=999`, asserts both stderr
   diagnostics (`invalid NUMA node` + `failed to create ... aborting`).

Verification performed on an 8-NUMA-node host with a gfx908 GPU:

- **Phase 1** — All three tests pass on a verification branch combining
  this commit with #38: 3 PASS / 0 FAIL / 1 WARN.
- **Phase 2 sensitivity** — Reverting `src/comms_mgr.cc` to
  `upstream/main` correctly flips `numa_node_0` and `numa_invalid_node`
  to FAIL, confirming the test exercises the integration point and does
  not pass on incidental side effects.
- Placement verified at runtime via `move_pages` returning the requested
  node for every allocation.

## Dependency on #38

The instrumented test harness currently hangs on non-CDNA3 GPUs (e.g.
gfx908 / MI100) without #38 (per-arch bitcode selection). This PR
touches **zero files in common with #38**, so once #38 merges
this PR rebases as a no-op. Runtime verification was therefore performed
on the combined branch; the C++ changes in this PR are independent of
#38.

## Follow-up

The `numa_invalid_node` test emits a `[WARN]` because the omniprobe
Python wrapper masks `SIGABRT` exit codes (tracking issue: #41).
The C++ abort path is fully validated via stderr diagnostics; once the
wrapper is fixed, the test's existing logic will automatically observe
`exit != 0` with no code change in this PR.